### PR TITLE
Restructure homepage hero for improved layout and hierarchy

### DIFF
--- a/themes/pine/assets/stylesheets/minimal.css
+++ b/themes/pine/assets/stylesheets/minimal.css
@@ -184,18 +184,30 @@ a { color: inherit; }
 :root[data-mode="auto"] .lm-ic-auto,
 :root:not([data-mode]) .lm-ic-auto { display: block; }
 
-/* ---- Intro ---- */
-.lm-intro {
-  display: flex;
-  align-items: flex-start;
-  gap: 34px;
-  padding: 80px 0 16px;
+/* ---- Intro (statement-first) ---- */
+.lm-intro { padding: 80px 0 8px; }
+.lm-intro-statement {
+  font-size: 40px;
+  line-height: 1.12;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  color: var(--ink);
+  margin: 0 0 28px;
+  max-width: 20ch;
 }
-.lm-intro-content { flex: 1; min-width: 0; }
+.lm-intro-meta {
+  display: flex;
+  gap: 26px;
+  align-items: flex-start;
+  padding-top: 26px;
+  border-top: 1px solid var(--hair);
+}
+.lm-intro-support { flex: 1; min-width: 0; }
+.lm-intro-support .lm-bio { margin: 0 0 18px; }
 .lm-portrait { margin: 0; flex-shrink: 0; }
 .lm-portrait img {
-  width: 140px;
-  height: 140px;
+  width: 96px;
+  height: 96px;
   border-radius: 12px;
   object-fit: cover;
   display: block;
@@ -213,14 +225,6 @@ a { color: inherit; }
   text-decoration-color: var(--hair);
 }
 .lm-portrait figcaption a:hover { color: var(--pine); }
-.lm-intro h1 {
-  font-size: 34px;
-  line-height: 1.18;
-  font-weight: 600;
-  letter-spacing: -0.01em;
-  margin: 0 0 24px;
-  max-width: 20ch;
-}
 .lm-bio {
   font-size: 19px;
   line-height: 1.65;
@@ -1399,9 +1403,10 @@ a { color: inherit; }
 /* ---- Responsive ---- */
 @media (max-width: 600px) {
   body { font-size: 17px; }
-  .lm-intro { flex-direction: column; gap: 18px; padding: 56px 0 12px; }
-  .lm-intro h1 { font-size: 28px; max-width: none; }
-  .lm-portrait img { width: 104px; height: 104px; }
+  .lm-intro { padding: 56px 0 8px; }
+  .lm-intro-statement { font-size: 30px; max-width: none; margin-bottom: 22px; }
+  .lm-intro-meta { gap: 18px; padding-top: 20px; }
+  .lm-portrait img { width: 80px; height: 80px; }
   .lm-portrait figcaption { font-size: 10px; }
   .lm-bio { font-size: 17px; }
   .lm-book-grid { grid-template-columns: repeat(2, 1fr); gap: 24px 18px; }

--- a/themes/pine/assets/stylesheets/minimal.css
+++ b/themes/pine/assets/stylesheets/minimal.css
@@ -185,19 +185,18 @@ a { color: inherit; }
 :root:not([data-mode]) .lm-ic-auto { display: block; }
 
 /* ---- Intro ---- */
-.lm-intro { padding: 80px 0 16px; }
-.lm-intro-head {
+.lm-intro {
   display: flex;
   align-items: flex-start;
-  gap: 26px;
-  margin: 0 0 24px;
+  gap: 34px;
+  padding: 80px 0 16px;
 }
-.lm-intro-head h1 { margin: 0; }
+.lm-intro-content { flex: 1; min-width: 0; }
 .lm-portrait { margin: 0; flex-shrink: 0; }
 .lm-portrait img {
-  width: 88px;
-  height: 88px;
-  border-radius: 10px;
+  width: 140px;
+  height: 140px;
+  border-radius: 12px;
   object-fit: cover;
   display: block;
 }
@@ -220,7 +219,7 @@ a { color: inherit; }
   font-weight: 600;
   letter-spacing: -0.01em;
   margin: 0 0 24px;
-  max-width: 18ch;
+  max-width: 20ch;
 }
 .lm-bio {
   font-size: 19px;
@@ -1400,10 +1399,9 @@ a { color: inherit; }
 /* ---- Responsive ---- */
 @media (max-width: 600px) {
   body { font-size: 17px; }
-  .lm-intro { padding: 56px 0 12px; }
-  .lm-intro h1 { font-size: 28px; }
-  .lm-intro-head { gap: 18px; }
-  .lm-portrait img { width: 66px; height: 66px; }
+  .lm-intro { flex-direction: column; gap: 18px; padding: 56px 0 12px; }
+  .lm-intro h1 { font-size: 28px; max-width: none; }
+  .lm-portrait img { width: 104px; height: 104px; }
   .lm-portrait figcaption { font-size: 10px; }
   .lm-bio { font-size: 17px; }
   .lm-book-grid { grid-template-columns: repeat(2, 1fr); gap: 24px 18px; }

--- a/themes/pine/assets/stylesheets/minimal.css
+++ b/themes/pine/assets/stylesheets/minimal.css
@@ -193,14 +193,14 @@ a { color: inherit; }
   letter-spacing: -0.02em;
   color: var(--ink);
   margin: 0 0 28px;
-  max-width: 20ch;
+  /* max-width: 20ch; */
 }
 .lm-intro-meta {
   display: flex;
   gap: 26px;
   align-items: flex-start;
-  padding-top: 26px;
-  border-top: 1px solid var(--hair);
+  /* padding-top: 26px;
+  border-top: 1px solid var(--hair); */
 }
 .lm-intro-support { flex: 1; min-width: 0; }
 .lm-intro-support .lm-bio { margin: 0 0 18px; }

--- a/themes/pine/layouts/index.html
+++ b/themes/pine/layouts/index.html
@@ -2,21 +2,21 @@
 
 {{/* 1 — Hero / intro */}}
 <section class="lm-intro">
-  <div class="lm-intro-head">
-    <figure class="lm-portrait">
-      <img src="/assets/images/portrait.webp" alt="Jason A. Heppler" width="95" height="95" loading="eager">
-      <figcaption>Photo by <a href="https://www.johnlegg.org/academic-photography">John Legg</a></figcaption>
-    </figure>
+  <figure class="lm-portrait">
+    <img src="/assets/images/portrait.webp" alt="Jason A. Heppler" width="140" height="140" loading="eager">
+    <figcaption>Photo by <a href="https://www.johnlegg.org/academic-photography">John Legg</a></figcaption>
+  </figure>
+  <div class="lm-intro-content">
     <h1>Historian of land and environmental politics in the North American West</h1>
-  </div>
-  <p class="lm-bio">Hi, I'm Jason A. Heppler, a historian writing about the twentieth century North American West, Great Plains, and Canadian Prairies. I'm the senior developer/scholar at the <a href="https://rrchnm.org">Roy Rosenzweig Center for History and New Media</a> and an Affiliate Fellow at the <a href="https://www.unl.edu/plains/">Center for Great Plains Studies</a> at the University of Nebraska-Lincoln.</p>
-  <div class="lm-social">
-    <a class="lm-email-link" data-name="jason" data-domain="jasonheppler.org">Email</a>
-    {{ with site.Params.social.bluesky }}<a href="{{ . }}">Bluesky</a>{{ end }}
-    {{ with site.Params.social.microblog }}<a href="{{ . }}">micro.blog</a>{{ end }}
-    {{ with site.Params.social.mastodon }}<a href="{{ . }}" rel="me">Mastodon</a>{{ end }}
-    {{ with site.Params.social.github }}<a href="{{ . }}">GitHub</a>{{ end }}
-    {{ with site.Params.social.buymeacoffee }}<a href="{{ . }}">Buy Me a Coffee</a>{{ end }}
+    <p class="lm-bio">Hi, I'm Jason A. Heppler, a historian writing about the twentieth century North American West, Great Plains, and Canadian Prairies. I'm the senior developer/scholar at the <a href="https://rrchnm.org">Roy Rosenzweig Center for History and New Media</a> and an Affiliate Fellow at the <a href="https://www.unl.edu/plains/">Center for Great Plains Studies</a> at the University of Nebraska-Lincoln.</p>
+    <div class="lm-social">
+      <a class="lm-email-link" data-name="jason" data-domain="jasonheppler.org">Email</a>
+      {{ with site.Params.social.bluesky }}<a href="{{ . }}">Bluesky</a>{{ end }}
+      {{ with site.Params.social.microblog }}<a href="{{ . }}">micro.blog</a>{{ end }}
+      {{ with site.Params.social.mastodon }}<a href="{{ . }}" rel="me">Mastodon</a>{{ end }}
+      {{ with site.Params.social.github }}<a href="{{ . }}">GitHub</a>{{ end }}
+      {{ with site.Params.social.buymeacoffee }}<a href="{{ . }}">Buy Me a Coffee</a>{{ end }}
+    </div>
   </div>
 </section>
 

--- a/themes/pine/layouts/index.html
+++ b/themes/pine/layouts/index.html
@@ -2,14 +2,14 @@
 
 {{/* 1 — Hero / intro */}}
 <section class="lm-intro">
-  <h1 class="lm-intro-statement">Historian of land and environmental politics in the North American West</h1>
+  <!-- <h1 class="lm-intro-statement">Historian of land and environmental politics in the North American West</h1> -->
   <div class="lm-intro-meta">
     <figure class="lm-portrait">
       <img src="/assets/images/portrait.webp" alt="Jason A. Heppler" width="96" height="96" loading="eager">
       <figcaption>Photo by <a href="https://www.johnlegg.org/academic-photography">John Legg</a></figcaption>
     </figure>
     <div class="lm-intro-support">
-      <p class="lm-bio">Hi, I'm Jason A. Heppler, a historian writing about the twentieth century North American West, Great Plains, and Canadian Prairies. I'm the senior developer/scholar at the <a href="https://rrchnm.org">Roy Rosenzweig Center for History and New Media</a> and an Affiliate Fellow at the <a href="https://www.unl.edu/plains/">Center for Great Plains Studies</a> at the University of Nebraska-Lincoln.</p>
+      <p class="lm-bio">I'm Jason A. Heppler, a historian of the North American West and Great Plains. I'm the senior developer/scholar at the <a href="https://rrchnm.org">Roy Rosenzweig Center for History and New Media</a> and an Affiliate Fellow at the <a href="https://www.unl.edu/plains/">Center for Great Plains Studies</a> at the University of Nebraska-Lincoln.</p>
       <div class="lm-social">
         <a class="lm-email-link" data-name="jason" data-domain="jasonheppler.org">Email</a>
         {{ with site.Params.social.bluesky }}<a href="{{ . }}">Bluesky</a>{{ end }}

--- a/themes/pine/layouts/index.html
+++ b/themes/pine/layouts/index.html
@@ -2,20 +2,22 @@
 
 {{/* 1 — Hero / intro */}}
 <section class="lm-intro">
-  <figure class="lm-portrait">
-    <img src="/assets/images/portrait.webp" alt="Jason A. Heppler" width="140" height="140" loading="eager">
-    <figcaption>Photo by <a href="https://www.johnlegg.org/academic-photography">John Legg</a></figcaption>
-  </figure>
-  <div class="lm-intro-content">
-    <h1>Historian of land and environmental politics in the North American West</h1>
-    <p class="lm-bio">Hi, I'm Jason A. Heppler, a historian writing about the twentieth century North American West, Great Plains, and Canadian Prairies. I'm the senior developer/scholar at the <a href="https://rrchnm.org">Roy Rosenzweig Center for History and New Media</a> and an Affiliate Fellow at the <a href="https://www.unl.edu/plains/">Center for Great Plains Studies</a> at the University of Nebraska-Lincoln.</p>
-    <div class="lm-social">
-      <a class="lm-email-link" data-name="jason" data-domain="jasonheppler.org">Email</a>
-      {{ with site.Params.social.bluesky }}<a href="{{ . }}">Bluesky</a>{{ end }}
-      {{ with site.Params.social.microblog }}<a href="{{ . }}">micro.blog</a>{{ end }}
-      {{ with site.Params.social.mastodon }}<a href="{{ . }}" rel="me">Mastodon</a>{{ end }}
-      {{ with site.Params.social.github }}<a href="{{ . }}">GitHub</a>{{ end }}
-      {{ with site.Params.social.buymeacoffee }}<a href="{{ . }}">Buy Me a Coffee</a>{{ end }}
+  <h1 class="lm-intro-statement">Historian of land and environmental politics in the North American West</h1>
+  <div class="lm-intro-meta">
+    <figure class="lm-portrait">
+      <img src="/assets/images/portrait.webp" alt="Jason A. Heppler" width="96" height="96" loading="eager">
+      <figcaption>Photo by <a href="https://www.johnlegg.org/academic-photography">John Legg</a></figcaption>
+    </figure>
+    <div class="lm-intro-support">
+      <p class="lm-bio">Hi, I'm Jason A. Heppler, a historian writing about the twentieth century North American West, Great Plains, and Canadian Prairies. I'm the senior developer/scholar at the <a href="https://rrchnm.org">Roy Rosenzweig Center for History and New Media</a> and an Affiliate Fellow at the <a href="https://www.unl.edu/plains/">Center for Great Plains Studies</a> at the University of Nebraska-Lincoln.</p>
+      <div class="lm-social">
+        <a class="lm-email-link" data-name="jason" data-domain="jasonheppler.org">Email</a>
+        {{ with site.Params.social.bluesky }}<a href="{{ . }}">Bluesky</a>{{ end }}
+        {{ with site.Params.social.microblog }}<a href="{{ . }}">micro.blog</a>{{ end }}
+        {{ with site.Params.social.mastodon }}<a href="{{ . }}" rel="me">Mastodon</a>{{ end }}
+        {{ with site.Params.social.github }}<a href="{{ . }}">GitHub</a>{{ end }}
+        {{ with site.Params.social.buymeacoffee }}<a href="{{ . }}">Buy Me a Coffee</a>{{ end }}
+      </div>
     </div>
   </div>
 </section>


### PR DESCRIPTION
This pull request updates the introduction section on the homepage to use a new "statement-first" layout and improves both visual hierarchy and responsiveness. The main changes involve restructuring the HTML to separate the headline statement from the bio, updating the CSS to support the new structure, and refining portrait and spacing styles for better appearance on all devices.

**Intro section layout and content updates:**

* Refactored the intro section in `index.html` to use `.lm-intro-meta` and `.lm-intro-support` containers, separating the headline (commented out for now) from the bio and social links, and updated the portrait image size. The intro bio text was also revised for clarity.
* Closed the new intro layout structure appropriately in the HTML.

**Styling and visual improvements:**

* Updated `.lm-intro`, `.lm-intro-statement`, `.lm-intro-meta`, and related CSS classes to support the new layout, including changes to padding, font sizes, and portrait image dimensions. Removed the old `.lm-intro-head` and `h1` styles. [[1]](diffhunk://#diff-36d69e7ec8c1be5c9dba7af13a31c92db5b203398227d7e25d9418f6bb04e28bL187-R211) [[2]](diffhunk://#diff-36d69e7ec8c1be5c9dba7af13a31c92db5b203398227d7e25d9418f6bb04e28bL217-L224)

**Responsive design enhancements:**

* Adjusted responsive CSS for the intro section, including smaller paddings, updated font sizes for `.lm-intro-statement`, and improved spacing and image sizing for mobile devices.