### PR TITLE
Make Sagebrush a standalone theme (one stylesheet)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -2,12 +2,10 @@ ignoreFiles:
   - _templates/
 
 title: Jason A. Heppler
-# Ordered theme fallback for the v11 "Sagebrush" redesign:
-# Hugo resolves project root -> sagebrush -> pine. Sagebrush (warm/serif,
-# Western book-hero) currently overrides only the homepage; everything else
-# falls back to Pine (minimal Fog & Pine) until reskinned into Sagebrush.
-# (themes/big-sky/ remains parked but is out of the active list.)
-theme: ["sagebrush", "pine"]
+# Sagebrush (warm/serif, Western book-hero) is the standalone site theme — it
+# owns every template, style, and script. themes/pine (minimal Fog & Pine) and
+# themes/big-sky remain parked in the tree as inactive references only.
+theme: sagebrush
 description: >-
   Jason Heppler is the senior web developer at the Roy Rosenzweig Center for
   History and New Media at George Mason University.

--- a/config.yaml
+++ b/config.yaml
@@ -2,9 +2,6 @@ ignoreFiles:
   - _templates/
 
 title: Jason A. Heppler
-# Sagebrush (warm/serif, Western book-hero) is the standalone site theme — it
-# owns every template, style, and script. themes/pine (minimal Fog & Pine) and
-# themes/big-sky remain parked in the tree as inactive references only.
 theme: sagebrush
 description: >-
   Jason Heppler is the senior web developer at the Roy Rosenzweig Center for

--- a/content/colophon.md
+++ b/content/colophon.md
@@ -15,7 +15,7 @@ Styles are plain, hand-written CSS---no framework, no utility classes---minified
 
 ## Typography
 
-The body text and interface are set in your device's native system font stack. The one typeface I do ship is **[JetBrains Mono](https://www.jetbrains.com/lp/mono/)**, self-hosted as a small WOFF2 file. It sets everything monospaced: code, the small uppercase labels, dates, footnotes, and figure captions.
+The body text and headings are set in **[Spectral](https://fonts.google.com/specimen/Spectral)**, a serif drawn for reading on screens. The interface---navigation, the small uppercase labels, dates, footnotes, code, and figure captions---is set in **[IBM Plex Mono](https://www.ibm.com/plex/)**. Both are self-hosted as small WOFF2 files, limited to the handful of weights the site actually uses; there are no third-party font services.
 
 ## Writing Environment
 
@@ -25,9 +25,9 @@ Content lives as flat Markdown files in the site's repository. I write in [Obsid
 
 Navigation sits in a simple top bar: my name in the top left links home, the section links sit to the right, and on narrow screens they collapse into a hamburger menu. The aim is to stay out of the way of the reading surface.
 
-The site supports **auto, light, and dark modes**, cycled with the toggle in the nav. The preference is stored in `localStorage` and applied before the page paints, so there's no flash of the wrong theme.
+The palette is a single warm, paper-inspired light theme---there's no dark mode or theme switcher. One carefully tuned set of colors, applied everywhere, so every page reads the way it was designed to.
 
-Performance and environmental footprint informed many choices: leaning on system fonts avoids web-font downloads almost entirely, images use lazy loading and `decoding="async"`, scripts are deferred, and the page weight on a typical post is kept small. The goal is a page that loads quickly on a slow connection and generates as little CO₂ as possible.
+Performance and environmental footprint informed many choices: the web fonts are self-hosted and subset rather than pulled from a third-party service, images use lazy loading and `decoding="async"`, scripts are deferred, and the page weight on a typical post is kept small. The goal is a page that loads quickly on a slow connection and generates as little CO₂ as possible.
 
 ## Content Types
 

--- a/content/page/nope.md
+++ b/content/page/nope.md
@@ -1,0 +1,21 @@
+---
+title: Nope
+url: /nope/
+---
+
+## Places You Won’t Find Me
+
+- Facebook
+- Goodreads
+- Pinterest
+- Threads
+- TikTok
+- Twitter/X (archive)
+
+## Things I Don’t Like
+
+- Being subscribed to anything I didn’t consent to.
+- Ads.
+- Having to install an app to do something that shouldn’t need an app.
+- Unsolicited offers, questions, or DMs from strangers that don’t attempt to make any personal connection.
+- Phone trees and chat bots.

--- a/themes/sagebrush/assets/javascripts/min-ui.js
+++ b/themes/sagebrush/assets/javascripts/min-ui.js
@@ -1,0 +1,41 @@
+// Fog & Pine theme UI: email obfuscation, mobile nav toggle, theme switcher.
+
+// Email obfuscation — build the address from data attributes on click.
+document.querySelectorAll('.lm-email-link').forEach(function (el) {
+  el.addEventListener('click', function () {
+    window.location.href = 'mailto:' + el.dataset.name + '@' + el.dataset.domain;
+  });
+});
+
+// Mobile hamburger nav.
+(function () {
+  var toggle = document.querySelector('.lm-nav-toggle');
+  var nav = document.getElementById('lmNav');
+  if (!toggle || !nav) return;
+  toggle.addEventListener('click', function () {
+    var open = nav.classList.toggle('lm-nav-open');
+    toggle.setAttribute('aria-expanded', open ? 'true' : 'false');
+  });
+  nav.querySelectorAll('a').forEach(function (a) {
+    a.addEventListener('click', function () {
+      nav.classList.remove('lm-nav-open');
+      toggle.setAttribute('aria-expanded', 'false');
+    });
+  });
+})();
+
+// Theme switcher: cycle auto -> light -> dark and persist.
+(function () {
+  var root = document.documentElement;
+  var btn = document.querySelector('.lm-theme');
+  if (!btn) return;
+  var order = ['auto', 'light', 'dark'];
+  btn.addEventListener('click', function () {
+    var cur = root.getAttribute('data-mode') || 'auto';
+    var next = order[(order.indexOf(cur) + 1) % order.length];
+    root.setAttribute('data-mode', next);
+    if (next === 'auto') root.removeAttribute('data-theme');
+    else root.setAttribute('data-theme', next);
+    try { localStorage.setItem('lm-theme-mode', next); } catch (e) {}
+  });
+})();

--- a/themes/sagebrush/assets/stylesheets/sagebrush.css
+++ b/themes/sagebrush/assets/stylesheets/sagebrush.css
@@ -1,3 +1,1462 @@
+/* Sagebrush — the standalone site theme (warm/serif, Western book-hero).
+   Base reset + lm- components (from the former Fog & Pine minimal.css) come
+   first; Sagebrush fonts, warm tokens, and bf-/tw- components follow and are
+   the sole token definitions. */
+
+* { box-sizing: border-box; }
+
+html { -webkit-text-size-adjust: 100%; }
+
+body {
+  margin: 0;
+  background: var(--paper);
+  color: var(--ink);
+  font-family: var(--sans);
+  font-size: 18px;
+  line-height: 1.6;
+  font-weight: 400;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+  transition: background-color 0.25s ease, color 0.25s ease;
+}
+
+a { color: inherit; }
+
+.lm-wrap {
+  max-width: var(--col);
+  margin: 0 auto;
+  padding: 0 24px;
+}
+
+/* ---- Top bar ---- */
+.lm-topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px 24px;
+  padding: 32px 0 0;
+}
+.lm-mark {
+  font-size: 18px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  color: var(--ink);
+  text-decoration: none;
+  white-space: nowrap;
+  flex-shrink: 0;
+  transition: color 0.15s ease;
+}
+.lm-mark:hover { color: var(--pine); }
+.lm-nav {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 10px 20px;
+  font-size: 16px;
+}
+.lm-nav a {
+  text-decoration: none;
+  color: var(--muted);
+  transition: color 0.15s ease;
+}
+.lm-nav a:hover { color: var(--pine); }
+.lm-nav a.lm-nav-active { color: var(--pine); }
+
+/* Hamburger toggle (mobile only) */
+.lm-nav-toggle {
+  display: none;
+  appearance: none;
+  background: none;
+  border: none;
+  padding: 4px;
+  margin: 0;
+  cursor: pointer;
+  color: var(--ink);
+  line-height: 0;
+  transition: color 0.15s ease;
+}
+.lm-nav-toggle:hover { color: var(--pine); }
+.lm-nav-toggle svg { display: block; }
+@media (max-width: 680px) {
+  .lm-topbar { flex-wrap: wrap; }
+  .lm-nav-toggle { display: inline-flex; }
+  .lm-nav {
+    display: none;
+    flex-basis: 100%;
+    flex-direction: column;
+    align-items: flex-start;
+    justify-content: flex-start;
+    gap: 2px;
+    margin-top: 14px;
+    padding-top: 14px;
+    border-top: 1px solid var(--hair);
+  }
+  .lm-nav.lm-nav-open { display: flex; }
+  .lm-nav a { padding: 9px 0; font-size: 17px; }
+  .lm-theme { margin-top: 8px; padding: 6px 0; }
+}
+
+/* Theme switcher */
+.lm-theme {
+  appearance: none;
+  background: none;
+  border: none;
+  padding: 0;
+  margin: 0;
+  cursor: pointer;
+  color: var(--muted);
+  display: inline-flex;
+  align-items: center;
+  line-height: 0;
+  transition: color 0.15s ease;
+}
+.lm-theme:hover { color: var(--pine); }
+.lm-theme svg { width: 18px; height: 18px; display: none; }
+:root[data-mode="light"] .lm-ic-light,
+:root[data-mode="dark"] .lm-ic-dark,
+:root[data-mode="auto"] .lm-ic-auto,
+:root:not([data-mode]) .lm-ic-auto { display: block; }
+
+/* ---- Intro (statement-first) ---- */
+.lm-intro { padding: 80px 0 8px; }
+.lm-intro-statement {
+  font-size: 40px;
+  line-height: 1.12;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  color: var(--ink);
+  margin: 0 0 28px;
+  /* max-width: 20ch; */
+}
+.lm-intro-meta {
+  display: flex;
+  gap: 26px;
+  align-items: flex-start;
+  /* padding-top: 26px;
+  border-top: 1px solid var(--hair); */
+}
+.lm-intro-support { flex: 1; min-width: 0; }
+.lm-intro-support .lm-bio { margin: 0 0 18px; }
+.lm-portrait { margin: 0; flex-shrink: 0; }
+.lm-portrait img {
+  width: 96px;
+  height: 96px;
+  border-radius: 12px;
+  object-fit: cover;
+  display: block;
+}
+.lm-portrait figcaption {
+  font-size: 11px;
+  color: var(--muted);
+  margin-top: 9px;
+  white-space: nowrap;
+  line-height: 1.4;
+}
+.lm-portrait figcaption a {
+  color: var(--muted);
+  text-decoration: underline;
+  text-decoration-color: var(--hair);
+}
+.lm-portrait figcaption a:hover { color: var(--pine); }
+.lm-bio {
+  font-size: 19px;
+  line-height: 1.65;
+  color: var(--ink);
+  margin: 0 0 22px;
+}
+.lm-bio a {
+  color: var(--pine);
+  text-decoration: none;
+  border-bottom: 1px solid var(--accent-line);
+}
+.lm-bio a:hover { border-bottom-color: var(--pine); }
+
+.lm-social {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 18px;
+  font-size: 15px;
+  color: var(--muted);
+}
+.lm-social a {
+  text-decoration: none;
+  color: var(--muted);
+  cursor: pointer;
+  transition: color 0.15s ease;
+}
+.lm-social a:hover { color: var(--pine); }
+
+/* ---- Sections ---- */
+.lm-section { padding: 56px 0 0; }
+.lm-label {
+  font-family: var(--mono);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--muted);
+  margin: 0 0 22px;
+}
+
+/* ---- Writing stream ---- */
+.lm-stream { display: flex; flex-direction: column; }
+.lm-row {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 20px;
+  padding: 13px 0;
+  border-top: 1px solid var(--hair);
+  text-decoration: none;
+}
+.lm-row:last-child { border-bottom: 1px solid var(--hair); }
+.lm-row-title {
+  color: var(--ink);
+  font-size: 18px;
+  transition: color 0.15s ease;
+}
+.lm-row:hover .lm-row-title { color: var(--pine); }
+.lm-row-date {
+  font-family: var(--mono);
+  font-size: 13px;
+  color: var(--muted);
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+/* ---- Books ---- */
+.lm-book-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 30px 24px;
+}
+.lm-book {
+  display: flex;
+  flex-direction: column;
+  text-decoration: none;
+}
+.lm-book-cover {
+  width: 100%;
+  height: auto;
+  display: block;
+  border-radius: 3px;
+  border: 1px solid var(--hair);
+  box-shadow: 0 2px 8px var(--cover-shadow);
+  margin-bottom: 14px;
+  transition: transform 0.18s ease, box-shadow 0.18s ease;
+}
+.lm-book:hover .lm-book-cover {
+  transform: translateY(-3px);
+  box-shadow: 0 6px 16px var(--cover-shadow-h);
+}
+.lm-book-title {
+  font-size: 15px;
+  font-weight: 500;
+  line-height: 1.3;
+  color: var(--ink);
+  transition: color 0.15s ease;
+}
+.lm-book:hover .lm-book-title { color: var(--pine); }
+.lm-book-meta {
+  font-size: 13px;
+  color: var(--muted);
+  margin-top: 4px;
+}
+.lm-more {
+  display: inline-block;
+  margin-top: 20px;
+  font-size: 15px;
+  color: var(--pine);
+  text-decoration: none;
+}
+.lm-more:hover { text-decoration: underline; }
+
+/* ---- Section head (label + trailing link) ---- */
+.lm-section-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 16px;
+}
+.lm-section-head .lm-label { margin-bottom: 0; }
+.lm-section-link {
+  font-size: 14px;
+  color: var(--pine);
+  text-decoration: none;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+.lm-section-link:hover { text-decoration: underline; }
+.lm-section-sub {
+  font-size: 16px;
+  color: var(--muted);
+  margin: 14px 0 22px;
+  max-width: 56ch;
+}
+
+/* ---- Featured callout ---- */
+.lm-callout {
+  display: flex;
+  gap: 22px;
+  align-items: stretch;
+  text-decoration: none;
+  border: 1px solid var(--hair);
+  border-radius: 10px;
+  padding: 18px;
+  background: var(--accent-glow);
+  transition: border-color 0.18s ease, transform 0.18s ease;
+}
+.lm-callout:hover { border-color: var(--accent-line); transform: translateY(-2px); }
+.lm-callout-media {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  width: 220px;
+  flex-shrink: 0;
+  align-self: flex-start;
+}
+.lm-callout-img {
+  width: 100%;
+  height: auto;
+  display: block;
+  border-radius: 6px;
+  border: 1px solid var(--hair);
+}
+.lm-callout-media .lm-btn {
+  margin-top: 0;
+  align-self: stretch;
+  text-align: center;
+}
+.lm-callout-body { display: flex; flex-direction: column; justify-content: center; }
+.lm-callout-eyebrow {
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--pine);
+  margin: 0 0 10px;
+}
+.lm-callout-desc {
+  font-size: 16px;
+  line-height: 1.55;
+  color: var(--ink);
+  margin: 0 0 16px;
+}
+.lm-btn {
+  display: inline-block;
+  align-self: flex-start;
+  margin-top: auto;
+  font-size: 14px;
+  font-weight: 500;
+  padding: 8px 16px;
+  border-radius: 7px;
+  background: var(--pine);
+  color: var(--btn-ink);
+  transition: background 0.15s ease;
+}
+.lm-callout:hover .lm-btn { background: var(--pine-deep); }
+
+/* ---- Essays / criticism list ---- */
+.lm-ec { display: flex; flex-direction: column; }
+.lm-ec-row {
+  display: grid;
+  grid-template-columns: 78px 1fr auto;
+  align-items: baseline;
+  gap: 6px 18px;
+  padding: 14px 0;
+  border-top: 1px solid var(--hair);
+  text-decoration: none;
+}
+.lm-ec-row:last-child { border-bottom: 1px solid var(--hair); }
+.lm-ec-info { display: flex; flex-direction: column; gap: 3px; }
+.lm-ec-title {
+  font-size: 17px;
+  line-height: 1.35;
+  color: var(--ink);
+  transition: color 0.15s ease;
+}
+.lm-ec-row:hover .lm-ec-title { color: var(--pine); }
+.lm-ec-row-static:hover .lm-ec-title { color: var(--ink); }
+.lm-ec-pub { font-size: 14px; color: var(--muted); }
+.lm-ec-year {
+  font-family: var(--mono);
+  font-size: 13px;
+  color: var(--muted);
+  white-space: nowrap;
+  text-align: right;
+}
+
+/* ---- On the road ---- */
+.lm-otr { display: flex; flex-direction: column; }
+.lm-otr-row {
+  display: grid;
+  grid-template-columns: 92px 1fr auto;
+  align-items: baseline;
+  gap: 6px 18px;
+  padding: 14px 0;
+  border-top: 1px solid var(--hair);
+}
+.lm-otr-row:last-child { border-bottom: 1px solid var(--hair); }
+.lm-otr-date {
+  font-family: var(--mono);
+  font-size: 13px;
+  color: var(--pine);
+  white-space: nowrap;
+}
+.lm-otr-info { display: flex; flex-direction: column; gap: 3px; }
+.lm-otr-title { font-size: 17px; line-height: 1.35; color: var(--ink); }
+.lm-otr-venue { font-size: 14px; color: var(--muted); }
+.lm-otr-link {
+  font-size: 14px;
+  color: var(--pine);
+  text-decoration: none;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+.lm-otr-link:hover { text-decoration: underline; }
+
+/* ---- About: roles ---- */
+.lm-roles {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 22px;
+  margin: 44px 0 0;
+}
+.lm-role { padding-top: 16px; border-top: 2px solid var(--pine); }
+.lm-role-title { font-size: 16px; font-weight: 600; margin: 0; line-height: 1.3; }
+.lm-role-org { font-size: 14px; color: var(--muted); margin: 6px 0 0; line-height: 1.45; }
+.lm-about-body { margin-top: 44px; }
+
+/* ---- About: stats ---- */
+.lm-stats {
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  gap: 20px;
+  margin: 48px 0 0;
+  padding: 28px 0;
+  border-top: 1px solid var(--hair);
+  border-bottom: 1px solid var(--hair);
+}
+.lm-stat { display: flex; flex-direction: column; align-items: center; gap: 6px; text-align: center; }
+.lm-stat-num {
+  font-size: 30px;
+  font-weight: 600;
+  color: var(--pine);
+  line-height: 1;
+  letter-spacing: -0.02em;
+}
+.lm-stat-label {
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+/* ---- About: link columns ---- */
+.lm-about-links {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 24px;
+  margin: 48px 0 0;
+}
+.lm-link-list { list-style: none; margin: 14px 0 0; padding: 0; }
+.lm-link-list li { margin: 0 0 8px; }
+.lm-link-list a { color: var(--pine); text-decoration: none; font-size: 16px; cursor: pointer; }
+.lm-link-list a:hover { text-decoration: underline; }
+
+/* ---- Research: project cards ---- */
+.lm-dh-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 18px;
+  margin: 40px 0 0;
+}
+.lm-project-card {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 20px;
+  border: 1px solid var(--hair);
+  border-radius: 10px;
+  text-decoration: none;
+  overflow: hidden;
+  transition: border-color 0.18s ease, transform 0.18s ease;
+}
+.lm-project-card:hover { border-color: var(--accent-line); transform: translateY(-2px); }
+.lm-project-card-img { padding: 0; gap: 0; }
+.lm-project-thumb {
+  width: 100%;
+  aspect-ratio: 16 / 10;
+  object-fit: cover;
+  display: block;
+  border-bottom: 1px solid var(--hair);
+  background: var(--field-bg);
+  transition: transform 0.25s ease;
+}
+.lm-project-card-img:hover .lm-project-thumb { transform: scale(1.03); }
+.lm-project-card-img .lm-project-body { padding: 15px 18px 18px; }
+.lm-project-body { display: flex; flex-direction: column; gap: 7px; }
+.lm-project-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+}
+.lm-project-title { font-size: 17px; font-weight: 600; color: var(--ink); line-height: 1.3; }
+.lm-project-arrow { color: var(--pine); flex-shrink: 0; font-size: 18px; }
+.lm-project-desc { font-size: 15px; line-height: 1.5; color: var(--muted); }
+
+/* ---- Publications: list ---- */
+.lm-pub-tabs {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 8px 16px;
+  margin: 20px 0 0;
+  font-size: 15px;
+}
+.lm-pub-tabs a { color: var(--pine); text-decoration: none; }
+.lm-pub-tabs a:hover { text-decoration: underline; }
+.lm-pub-tab-cv { font-family: var(--mono); font-size: 13px; }
+.lm-pub-h2 {
+  font-size: 22px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  margin: 56px 0 24px;
+  padding-bottom: 10px;
+  border-bottom: 1px solid var(--hair);
+  scroll-margin-top: 20px;
+}
+.lm-pub-card { display: flex; gap: 24px; margin: 0 0 36px; }
+.lm-pub-card-cover { flex-shrink: 0; width: 140px; }
+.lm-pub-card-cover img {
+  width: 100%;
+  height: auto;
+  display: block;
+  border-radius: 4px;
+  border: 1px solid var(--hair);
+  box-shadow: 0 2px 8px var(--cover-shadow);
+  transition: transform 0.18s ease, box-shadow 0.18s ease;
+}
+.lm-pub-card-cover:hover img { transform: translateY(-3px); box-shadow: 0 6px 16px var(--cover-shadow-h); }
+.lm-pub-card-info { display: flex; flex-direction: column; }
+.lm-pub-card-title { font-size: 19px; font-weight: 600; line-height: 1.25; margin: 0; }
+.lm-pub-card-meta { font-size: 14px; color: var(--muted); margin: 6px 0 0; }
+.lm-pub-card-desc { font-size: 16px; line-height: 1.55; color: var(--ink); margin: 12px 0 0; }
+.lm-pub-card-desc p { margin: 0; }
+.lm-pub-card-info .lm-more { margin-top: 12px; }
+.lm-pub-list { margin: 0 0 16px; padding-left: 1.4em; }
+.lm-pub-list li { margin: 0 0 14px; font-size: 16px; line-height: 1.55; color: var(--ink); }
+.lm-pub-list a { color: var(--pine); text-decoration: none; border-bottom: 1px solid var(--accent-line); }
+.lm-pub-list a:hover { border-bottom-color: var(--pine); }
+
+/* ---- Publications: book detail ---- */
+.lm-breadcrumb {
+  display: inline-block;
+  font-size: 14px;
+  color: var(--muted);
+  text-decoration: none;
+  margin: 8px 0 28px;
+}
+.lm-breadcrumb:hover { color: var(--pine); }
+.lm-bookhead { display: flex; gap: 36px; align-items: flex-start; }
+.lm-bookhead-cover { flex-shrink: 0; width: 220px; position: sticky; top: 24px; }
+.lm-bookhead-cover img {
+  width: 100%;
+  height: auto;
+  display: block;
+  border-radius: 4px;
+  border: 1px solid var(--hair);
+  box-shadow: 0 4px 16px var(--cover-shadow);
+}
+.lm-bookhead-info { flex: 1; min-width: 0; }
+.lm-bookhead-title {
+  font-size: 30px;
+  font-weight: 600;
+  line-height: 1.15;
+  letter-spacing: -0.015em;
+  margin: 10px 0 0;
+}
+.lm-bookhead-author { font-size: 17px; color: var(--ink); margin: 10px 0 0; }
+.lm-bookhead-publisher { font-size: 15px; color: var(--muted); margin: 4px 0 0; }
+.lm-bookhead-buy { display: flex; flex-wrap: wrap; gap: 10px; margin: 22px 0 0; }
+.lm-bookhead-buy .lm-btn { margin-top: 0; }
+.lm-bookhead-prose { margin-top: 24px; font-size: 17px; }
+.lm-btn-outline {
+  background: none;
+  color: var(--pine);
+  border: 1px solid var(--accent-line);
+}
+.lm-btn-outline:hover { background: var(--accent-glow); }
+
+.lm-praise {
+  margin: 56px 0 0;
+  padding: 32px 0;
+  border-top: 1px solid var(--hair);
+  border-bottom: 1px solid var(--hair);
+}
+.lm-praise-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 24px; margin-top: 18px; }
+.lm-praise-quote { margin: 0; padding-left: 16px; border-left: 2px solid var(--pine); }
+.lm-praise-quote p { font-size: 16px; line-height: 1.55; font-style: italic; color: var(--ink); margin: 0 0 8px; }
+.lm-praise-quote cite { font-size: 14px; color: var(--muted); font-style: normal; }
+
+.lm-reviews { margin: 48px 0 0; }
+.lm-review-quote { margin: 18px 0 0; padding-left: 16px; border-left: 2px solid var(--hair); }
+.lm-review-quote p { font-size: 16px; line-height: 1.55; color: var(--ink); margin: 0 0 8px; }
+.lm-review-quote cite { font-size: 14px; color: var(--muted); font-style: normal; }
+.lm-review-quote cite a { color: var(--pine); text-decoration: none; }
+.lm-review-quote cite a:hover { text-decoration: underline; }
+
+.lm-buy-footer { margin: 48px 0 0; padding-top: 24px; border-top: 1px solid var(--hair); }
+.lm-buy-links { font-size: 16px; color: var(--muted); margin: 14px 0 0; }
+.lm-buy-links a { color: var(--pine); text-decoration: none; }
+.lm-buy-links a:hover { text-decoration: underline; }
+
+.lm-isbn { margin: 36px 0 0; }
+.lm-isbn-grid { display: flex; flex-wrap: wrap; gap: 28px; }
+.lm-isbn-item { display: flex; flex-direction: column; gap: 4px; }
+.lm-isbn-label {
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+.lm-isbn-number { font-family: var(--mono); font-size: 14px; color: var(--ink); }
+
+/* ---- Bookshelf ---- */
+.lm-shelf { display: flex; flex-direction: column; margin-top: 10px; }
+.lm-shelf-entry { border-top: 1px solid var(--hair); }
+.lm-shelf-entry:last-child { border-bottom: 1px solid var(--hair); }
+.lm-shelf-row {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 20px;
+  padding: 13px 0;
+}
+.lm-shelf-details > summary { list-style: none; cursor: pointer; }
+.lm-shelf-details > summary::-webkit-details-marker { display: none; }
+.lm-shelf-details > summary::marker { content: ''; }
+.lm-shelf-details > summary:hover .lm-shelf-title { color: var(--pine); }
+.lm-shelf-details[open] .lm-shelf-title { color: var(--pine); }
+.lm-shelf-info { display: flex; flex-direction: column; gap: 3px; }
+.lm-shelf-title { font-size: 17px; color: var(--ink); transition: color 0.15s ease; }
+.lm-shelf-meta { font-size: 14px; color: var(--muted); }
+.lm-shelf-year { font-family: var(--mono); font-size: 13px; color: var(--muted); white-space: nowrap; flex-shrink: 0; }
+.lm-reviewed {
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--pine);
+  text-decoration: none;
+  border: 1px solid var(--accent-line);
+  border-radius: 4px;
+  padding: 1px 6px;
+  margin-right: 6px;
+}
+.lm-shelf-expanded {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px 16px;
+  padding: 0 0 14px;
+  font-size: 13px;
+  color: var(--muted);
+}
+.lm-shelf-isbn { font-family: var(--mono); }
+.lm-shelf-links { display: flex; gap: 14px; }
+.lm-shelf-links a { color: var(--pine); text-decoration: none; }
+.lm-shelf-links a:hover { text-decoration: underline; }
+.lm-shelf-publisher { font-style: italic; }
+
+/* ---- Generic pages, taxonomy, courses ---- */
+.lm-page-body { margin-top: 32px; }
+.lm-tag-cloud { display: flex; flex-wrap: wrap; gap: 10px; margin: 36px 0 0; }
+.lm-tag-chip {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 6px;
+  font-size: 15px;
+  padding: 7px 14px;
+  border: 1px solid var(--hair);
+  border-radius: 999px;
+  color: var(--ink);
+  text-decoration: none;
+  transition: color 0.15s ease, border-color 0.15s ease;
+}
+.lm-tag-chip:hover { color: var(--pine); border-color: var(--accent-line); }
+.lm-course-meta {
+  margin: 28px 0 0;
+  padding: 16px 18px;
+  border: 1px solid var(--hair);
+  border-radius: 8px;
+  background: var(--accent-glow);
+  font-size: 15px;
+  color: var(--muted);
+}
+.lm-course-meta p { margin: 0 0 8px; line-height: 1.5; }
+.lm-course-meta p:last-child { margin-bottom: 0; }
+.lm-course-meta strong { color: var(--ink); }
+.lm-course-meta a { color: var(--pine); text-decoration: none; }
+.lm-404 { padding: 80px 0 64px; }
+
+/* ---- Blogroll: 3-column link list ---- */
+.lm-blogroll ul {
+  columns: 3;
+  column-gap: 30px;
+  list-style: none;
+  padding: 0;
+  margin: 28px 0 0;
+}
+.lm-blogroll li { margin: 0 0 14px; break-inside: avoid; }
+
+/* ---- Teaching: course rows (course left, date right) ---- */
+.lm-prose .teaching { margin: 24px 0 0; }
+.lm-prose .teaching > div {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 20px;
+  padding: 13px 0;
+  border-top: 1px solid var(--hair);
+}
+.lm-prose .teaching > div:last-child { border-bottom: 1px solid var(--hair); }
+.lm-prose .teaching > div > div:first-child { font-size: 17px; color: var(--ink); }
+.lm-prose .teaching > div > div:last-child {
+  font-family: var(--mono);
+  font-size: 13px;
+  color: var(--muted);
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+.lm-prose .teaching a { border-bottom: none; }
+
+/* ---- Galleries + lightbox ---- */
+.lm-prose .masonry-grid {
+  columns: 3;
+  column-gap: 12px;
+  margin: 36px 0;
+}
+.lm-prose .masonry-grid img {
+  width: 100%;
+  display: block;
+  margin: 0 0 12px;
+  border-radius: 4px;
+  cursor: zoom-in;
+}
+@media (max-width: 860px) { .lm-prose .masonry-grid { columns: 2; } }
+@media (max-width: 520px) { .lm-prose .masonry-grid { columns: 1; } }
+.photo-lightbox {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.88);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  cursor: zoom-out;
+}
+.photo-lightbox img {
+  max-width: 92vw;
+  max-height: 92vh;
+  object-fit: contain;
+  border-radius: 4px;
+  box-shadow: 0 8px 40px rgba(0, 0, 0, 0.5);
+}
+
+/* ---- Low-impact metrics panel ---- */
+.metrics_container {
+  display: grid;
+  grid-template-columns: 1fr 1.4fr;
+  margin: 36px 0;
+  border: 1px solid var(--hair);
+  border-radius: 10px;
+  overflow: hidden;
+}
+.metrics-left {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 14px;
+  text-align: center;
+  background: var(--panel-green);
+  padding: 36px 28px;
+}
+.metrics-left p {
+  font-size: 17px;
+  line-height: 1.6;
+  color: rgba(255, 255, 255, 0.85);
+  margin: 0;
+}
+.metrics-left strong { color: #fff; }
+.metrics__img { width: 40px; height: 40px; filter: brightness(0) invert(1); opacity: 0.85; }
+.metrics-right {
+  display: flex;
+  align-items: center;
+  padding: 32px;
+  background: var(--accent-glow);
+}
+.metrics-right p {
+  font-size: 17px;
+  line-height: 1.65;
+  color: var(--ink);
+  margin: 0;
+  text-align: right;
+}
+
+/* ---- Microblog list (full posts + pagination) ---- */
+.lm-mb-list { display: flex; flex-direction: column; gap: 26px; margin: 36px 0 0; }
+.lm-mb-post {
+  border: 1px solid var(--hair);
+  border-radius: 12px;
+  padding: 20px 24px 22px;
+  transition: border-color 0.18s ease;
+}
+.lm-mb-post:hover { border-color: var(--accent-line); }
+.lm-mb-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 16px;
+  padding-bottom: 14px;
+  margin-bottom: 16px;
+  border-bottom: 1px solid var(--hair);
+}
+.lm-mb-title { font-size: 20px; font-weight: 600; line-height: 1.25; margin: 0; }
+.lm-mb-title a { color: var(--ink); text-decoration: none; transition: color 0.15s ease; }
+.lm-mb-title a:hover { color: var(--pine); }
+.lm-mb-date {
+  font-family: var(--mono);
+  font-size: 13px;
+  color: var(--muted);
+  white-space: nowrap;
+  flex-shrink: 0;
+  text-decoration: none;
+  transition: color 0.15s ease;
+}
+.lm-mb-date:hover { color: var(--pine); }
+.lm-mb-post .lm-mb-body { margin: 0; font-size: 17px; }
+.lm-mb-body > :first-child { margin-top: 0; }
+.lm-mb-body > :last-child { margin-bottom: 0; }
+.lm-mb-tags {
+  font-size: 14px;
+  color: var(--muted);
+  margin: 16px 0 0;
+  padding-top: 14px;
+  border-top: 1px solid var(--hair);
+}
+.lm-mb-tags a { color: var(--pine); text-decoration: none; }
+.lm-mb-tags a:hover { text-decoration: underline; }
+
+/* Microblog single — card header idiom, no box */
+.lm-mb-single-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 6px 24px;
+  padding-bottom: 16px;
+  border-bottom: 1px solid var(--hair);
+}
+.lm-mb-single-head .lm-article-title { margin: 0; }
+.lm-mb-single-head .lm-mb-date { font-size: 14px; }
+
+/* Pagination */
+.lm-pager {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  margin: 36px 0 0;
+  padding-top: 22px;
+  border-top: 1px solid var(--hair);
+  font-size: 15px;
+}
+.lm-pager-link { color: var(--pine); text-decoration: none; }
+.lm-pager-link:hover { text-decoration: underline; }
+.lm-pager-off { color: var(--muted); opacity: 0.45; }
+.lm-pager-count {
+  font-family: var(--mono);
+  font-size: 12px;
+  letter-spacing: 0.04em;
+  color: var(--muted);
+}
+
+/* ---- Newsletter ---- */
+.lm-news { padding: 64px 0 0; }
+.lm-news p { color: var(--muted); font-size: 16px; margin: 0 0 16px; }
+.lm-form { display: flex; gap: 10px; max-width: 420px; }
+.lm-form input {
+  flex: 1;
+  font-family: var(--sans);
+  font-size: 16px;
+  padding: 11px 14px;
+  border: 1px solid var(--hair);
+  border-radius: 7px;
+  background: var(--field-bg);
+  color: var(--ink);
+}
+.lm-form input:focus {
+  outline: none;
+  border-color: var(--pine);
+  box-shadow: 0 0 0 3px var(--accent-glow);
+}
+.lm-form button {
+  font-family: var(--sans);
+  font-size: 16px;
+  padding: 11px 20px;
+  border: none;
+  border-radius: 7px;
+  background: var(--pine);
+  color: var(--btn-ink);
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+.lm-form button:hover { background: var(--pine-deep); }
+
+/* ---- Footer ---- */
+.lm-footer {
+  margin-top: 80px;
+  padding: 28px 0 56px;
+  border-top: 1px solid var(--hair);
+  font-family: var(--mono);
+  font-size: 13px;
+  line-height: 1.7;
+  color: var(--muted);
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px 18px;
+  justify-content: space-between;
+}
+.lm-footer a { color: var(--muted); text-decoration: none; }
+.lm-footer a:hover { color: var(--pine); }
+.lm-footer .lm-foot-rss { display: flex; gap: 16px; }
+
+/* ---- Post / article ---- */
+.lm-article-head { padding: 72px 0 0; }
+.lm-article-title {
+  font-size: 38px;
+  line-height: 1.14;
+  font-weight: 600;
+  letter-spacing: -0.015em;
+  margin: 14px 0 0;
+}
+.lm-article-lede {
+  font-size: 21px;
+  line-height: 1.5;
+  color: var(--muted);
+  margin: 18px 0 0;
+}
+.lm-article-meta {
+  display: flex;
+  align-items: center;
+  font-family: var(--mono);
+  font-size: 13px;
+  color: var(--muted);
+  margin: 24px 0 0;
+}
+.lm-dot-sep { margin: 0 9px; opacity: 0.5; }
+
+.lm-article-lead { margin: 44px 0 0; }
+.lm-article-lead img {
+  width: 100%;
+  height: auto;
+  display: block;
+  border-radius: 4px;
+}
+
+/* Prose */
+.lm-prose {
+  margin: 44px 0 0;
+  font-size: 19px;
+  line-height: 1.72;
+  color: var(--ink);
+}
+.lm-prose > p:first-child { margin-top: 0; }
+.lm-prose p { margin: 0 0 1.3em; }
+.lm-prose a {
+  color: var(--pine);
+  text-decoration: none;
+  border-bottom: 1px solid var(--accent-line);
+}
+.lm-prose a:hover { border-bottom-color: var(--pine); }
+.lm-prose h2 {
+  font-size: 26px;
+  font-weight: 600;
+  line-height: 1.2;
+  letter-spacing: -0.01em;
+  margin: 1.7em 0 0.5em;
+}
+.lm-prose h3 {
+  font-size: 21px;
+  font-weight: 600;
+  line-height: 1.25;
+  margin: 1.6em 0 0.4em;
+}
+.lm-prose ul, .lm-prose ol { margin: 0 0 1.3em; padding-left: 1.4em; }
+.lm-prose li { margin: 0 0 0.5em; }
+.lm-prose blockquote {
+  margin: 1.6em 0;
+  padding: 2px 0 2px 20px;
+  border-left: 2px solid var(--pine);
+  color: var(--muted);
+  font-style: italic;
+}
+.lm-prose blockquote p:last-child { margin-bottom: 0; }
+.lm-prose code {
+  font-family: var(--mono);
+  font-size: 0.85em;
+  background: var(--field-bg);
+  border: 1px solid var(--hair);
+  border-radius: 4px;
+  padding: 1px 5px;
+}
+.lm-prose pre {
+  background: var(--field-bg);
+  border: 1px solid var(--hair);
+  border-radius: 8px;
+  padding: 16px 18px;
+  overflow-x: auto;
+  margin: 1.5em 0;
+  font-size: 15px;
+  line-height: 1.5;
+}
+.lm-prose pre code { background: none; border: none; padding: 0; font-size: inherit; }
+.lm-prose img { max-width: 100%; height: auto; border-radius: 4px; margin: 1.5em 0; }
+
+/* Figures */
+.lm-prose figure { margin: 2.2em 0; text-align: center; }
+.lm-prose figure img,
+.lm-prose figure img.full-width {
+  display: block;
+  max-width: 100%;
+  height: auto;
+  margin: 0 auto;
+  border-radius: 4px;
+}
+.lm-prose figcaption {
+  margin-top: 12px;
+  font-family: var(--mono);
+  font-size: 12px;
+  line-height: 1.55;
+  letter-spacing: 0.01em;
+  color: var(--muted);
+  text-align: center;
+}
+.lm-prose figcaption p { margin: 6px 0 0; }
+.lm-prose figcaption p:first-child { margin-top: 0; }
+.lm-prose figcaption a { color: var(--pine); text-decoration: none; border-bottom: 1px solid var(--accent-line); }
+
+/* Tables */
+.lm-prose table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 1.9em 0;
+  font-size: 16px;
+  line-height: 1.5;
+}
+.lm-prose thead th {
+  text-align: left;
+  font-family: var(--mono);
+  font-size: 12px;
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--muted);
+  padding: 0 14px 10px;
+  border-bottom: 1px solid var(--accent-line);
+}
+.lm-prose tbody td {
+  padding: 11px 14px;
+  border-bottom: 1px solid var(--hair);
+  vertical-align: top;
+  color: var(--ink);
+}
+.lm-prose tbody tr:last-child td { border-bottom: none; }
+.lm-prose th:first-child,
+.lm-prose td:first-child { padding-left: 0; }
+.lm-prose th:last-child,
+.lm-prose td:last-child { padding-right: 0; }
+.lm-prose table code { white-space: nowrap; }
+.lm-prose hr { border: none; border-top: 1px solid var(--hair); margin: 2.4em 0; }
+.lm-prose aside,
+.lm-archive-lead aside {
+  font-size: 15px;
+  line-height: 1.65;
+  color: var(--muted);
+  background: var(--accent-glow);
+  border-left: 3px solid var(--pine);
+  border-radius: 0 8px 8px 0;
+  padding: 14px 18px;
+  margin: 1.6em 0;
+}
+.lm-prose aside p,
+.lm-archive-lead aside p { margin: 0 0 0.6em; font-size: inherit; }
+.lm-prose aside p:last-child,
+.lm-archive-lead aside p:last-child { margin-bottom: 0; }
+.lm-prose aside a,
+.lm-archive-lead aside a { color: var(--pine); text-decoration: none; border-bottom: 1px solid var(--accent-line); }
+.lm-prose aside strong,
+.lm-archive-lead aside strong { color: var(--ink); }
+.lm-prose strong { font-weight: 600; }
+.lm-prose sup a { font-family: var(--mono); font-size: 0.8em; color: var(--pine); border: none; text-decoration: none; }
+.lm-prose .footnotes {
+  margin-top: 2.6em;
+  padding-top: 1.2em;
+  border-top: 1px solid var(--hair);
+  font-family: var(--mono);
+  font-size: 13px;
+  line-height: 1.7;
+  color: var(--muted);
+}
+.lm-prose .footnotes ol { padding-left: 1.2em; }
+.lm-prose .footnotes li { margin: 0 0 0.6em; }
+.lm-prose .footnote-backref { border: none; }
+
+/* Article footer meta */
+.lm-article-footer {
+  margin: 48px 0 0;
+  padding-top: 22px;
+  border-top: 1px solid var(--hair);
+}
+.lm-post-note { font-size: 15px; color: var(--muted); margin: 0; }
+.lm-post-note a { color: var(--pine); text-decoration: none; }
+.lm-tags { font-size: 15px; color: var(--muted); margin: 12px 0 0; }
+.lm-tags a { color: var(--pine); text-decoration: none; }
+.lm-tags a:hover { text-decoration: underline; }
+
+/* Post footer meta row (carbon badge · tags) */
+.lm-post-meta {
+  font-size: 15px;
+  line-height: 1.7;
+  color: var(--muted);
+  margin: 12px 0 0;
+}
+.lm-post-meta a { color: var(--pine); text-decoration: none; }
+.lm-post-meta a:hover { text-decoration: none; color: var(--pine-deep) }
+.lm-carbon {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  vertical-align: baseline;
+}
+.lm-carbon-leaf { flex-shrink: 0; }
+.lm-carbon sub { font-size: 0.7em; vertical-align: -0.15em; }
+
+/* Commonplace outbound link */
+.lm-link-out { margin-top: 1.6em; }
+.lm-link-out a { font-weight: 500; border-bottom: 1px solid var(--accent-line); }
+
+/* Author card */
+.lm-author {
+  margin: 36px 0 0;
+  padding: 22px 0;
+  border-top: 1px solid var(--hair);
+  border-bottom: 1px solid var(--hair);
+  display: flex;
+  align-items: center;
+  gap: 14px;
+}
+.lm-author img { width: 56px; height: 56px; border-radius: 50%; object-fit: cover; flex-shrink: 0; }
+.lm-author-text { display: flex; flex-direction: column; }
+.lm-author-name { font-weight: 600; font-size: 16px; }
+.lm-author-role { font-size: 14px; color: var(--muted); }
+.lm-author-links { margin-left: auto; display: flex; gap: 14px; font-size: 14px; }
+.lm-author-links a { color: var(--muted); text-decoration: none; transition: color 0.15s ease; }
+.lm-author-links a:hover { color: var(--pine); }
+
+/* Prev / next */
+.lm-prevnext {
+  margin: 40px 0 0;
+  display: flex;
+  justify-content: space-between;
+  gap: 24px;
+}
+.lm-prevnext-item {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  text-decoration: none;
+  max-width: 46%;
+}
+.lm-prevnext-next { text-align: right; align-items: flex-end; }
+.lm-prevnext-label {
+  font-family: var(--mono);
+  font-size: 12px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+.lm-prevnext-title { font-size: 16px; line-height: 1.3; color: var(--ink); transition: color 0.15s ease; }
+.lm-prevnext-item:hover .lm-prevnext-title { color: var(--pine); }
+
+/* Related reading */
+.lm-related { margin: 56px 0 0; }
+.lm-related-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 22px;
+}
+.lm-related-item {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding-top: 16px;
+  border-top: 1px solid var(--hair);
+  text-decoration: none;
+}
+.lm-related-title {
+  font-size: 16px;
+  line-height: 1.3;
+  color: var(--ink);
+  transition: color 0.15s ease;
+}
+.lm-related-item:hover .lm-related-title { color: var(--pine); }
+.lm-related-date {
+  font-family: var(--mono);
+  font-size: 12px;
+  color: var(--muted);
+}
+
+/* ---- Archive / list ---- */
+.lm-archive-head { padding: 72px 0 0; }
+.lm-archive-title {
+  font-size: 34px;
+  line-height: 1.16;
+  font-weight: 600;
+  letter-spacing: -0.015em;
+  margin: 14px 0 0;
+}
+.lm-archive-lead {
+  font-size: 18px;
+  line-height: 1.55;
+  color: var(--muted);
+  margin: 16px 0 0;
+  max-width: 54ch;
+}
+.lm-archive-controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 14px;
+  margin: 40px 0 0;
+}
+.lm-chips { display: flex; flex-wrap: wrap; gap: 8px; }
+.lm-chip {
+  font-family: var(--sans);
+  font-size: 14px;
+  padding: 6px 14px;
+  border: 1px solid var(--hair);
+  border-radius: 999px;
+  background: none;
+  color: var(--muted);
+  cursor: pointer;
+  transition: color 0.15s ease, background 0.15s ease, border-color 0.15s ease;
+}
+.lm-chip:hover { color: var(--pine); border-color: var(--accent-line); }
+.lm-chip.on {
+  background: var(--pine);
+  color: var(--btn-ink);
+  border-color: var(--pine);
+}
+.lm-chip-n { opacity: 0.6; font-size: 12px; }
+.lm-search {
+  font-family: var(--sans);
+  font-size: 15px;
+  padding: 9px 14px;
+  border: 1px solid var(--hair);
+  border-radius: 7px;
+  background: var(--field-bg);
+  color: var(--ink);
+  min-width: 200px;
+}
+.lm-search:focus {
+  outline: none;
+  border-color: var(--pine);
+  box-shadow: 0 0 0 3px var(--accent-glow);
+}
+.lm-archive-count {
+  font-family: var(--mono);
+  font-size: 12px;
+  color: var(--muted);
+  margin: 22px 0 0;
+}
+.lm-archive-list { margin: 10px 0 0; display: flex; flex-direction: column; }
+.lm-archive-row {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 20px;
+  padding: 14px 0;
+  border-top: 1px solid var(--hair);
+  text-decoration: none;
+}
+.lm-archive-row:last-child { border-bottom: 1px solid var(--hair); }
+.lm-archive-row-title {
+  font-size: 18px;
+  line-height: 1.35;
+  color: var(--ink);
+  transition: color 0.15s ease;
+}
+.lm-archive-row:hover .lm-archive-row-title { color: var(--pine); }
+.lm-archive-row-source {
+  font-family: var(--mono);
+  font-size: 12px;
+  color: var(--muted);
+}
+.lm-archive-row-meta {
+  display: flex;
+  align-items: baseline;
+  gap: 14px;
+  flex-shrink: 0;
+}
+.lm-type {
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+.lm-type-essay { color: var(--pine); }
+.lm-archive-date {
+  font-family: var(--mono);
+  font-size: 13px;
+  color: var(--muted);
+  white-space: nowrap;
+}
+.lm-archive-empty {
+  font-size: 16px;
+  color: var(--muted);
+  margin: 24px 0 0;
+}
+
+/* ---- Responsive ---- */
+@media (max-width: 600px) {
+  body { font-size: 17px; }
+  .lm-intro { padding: 56px 0 8px; }
+  .lm-intro-statement { font-size: 30px; max-width: none; margin-bottom: 22px; }
+  .lm-intro-meta { gap: 18px; padding-top: 20px; }
+  .lm-portrait img { width: 80px; height: 80px; }
+  .lm-portrait figcaption { font-size: 10px; }
+  .lm-bio { font-size: 17px; }
+  .lm-book-grid { grid-template-columns: repeat(2, 1fr); gap: 24px 18px; }
+  .lm-form { flex-direction: column; }
+  .lm-footer { flex-direction: column; }
+
+  .lm-callout { flex-direction: column; gap: 16px; }
+  .lm-callout-media { width: 100%; }
+  .lm-ec-row { grid-template-columns: 1fr auto; }
+  .lm-ec-row .lm-type { grid-column: 1 / -1; }
+  .lm-otr-row { grid-template-columns: 1fr auto; }
+  .lm-otr-row .lm-otr-date { grid-column: 1 / -1; }
+  .lm-roles { grid-template-columns: 1fr; gap: 18px; }
+  .lm-stats { grid-template-columns: repeat(2, 1fr); gap: 22px 16px; }
+  .lm-about-links { grid-template-columns: 1fr; gap: 28px; }
+  .lm-dh-grid { grid-template-columns: 1fr; }
+  .lm-pub-card { gap: 18px; }
+  .lm-pub-card-cover { width: 96px; }
+  .lm-bookhead { flex-direction: column; gap: 24px; }
+  .lm-bookhead-cover { position: static; width: 160px; }
+  .lm-praise-grid { grid-template-columns: 1fr; }
+  .lm-shelf-expanded { gap: 6px 12px; }
+  .lm-shelf-links { gap: 12px; }
+  .metrics_container { grid-template-columns: 1fr; }
+  .metrics-right p { text-align: left; }
+  .lm-blogroll ul { columns: 2; }
+
+  .lm-article-head { padding: 48px 0 0; }
+  .lm-article-title { font-size: 30px; }
+  .lm-article-lede { font-size: 18px; }
+  .lm-prose { font-size: 18px; }
+  .lm-prose h2 { font-size: 23px; }
+  .lm-prose h3 { font-size: 19px; }
+  .lm-author { flex-wrap: wrap; }
+  .lm-author-links { margin-left: 0; flex-basis: 100%; }
+  .lm-prevnext { flex-direction: column; gap: 22px; }
+  .lm-prevnext-item, .lm-prevnext-next { max-width: 100%; text-align: left; align-items: flex-start; }
+  .lm-related-grid { grid-template-columns: 1fr; gap: 0; }
+  .lm-related-item { padding-top: 14px; padding-bottom: 14px; }
+  .lm-related-item:last-child { border-bottom: 1px solid var(--hair); }
+
+  .lm-archive-head { padding: 48px 0 0; }
+  .lm-archive-title { font-size: 28px; }
+  .lm-archive-controls { flex-direction: column; align-items: stretch; }
+  .lm-search { min-width: 0; }
+  .lm-archive-row { flex-wrap: wrap; gap: 4px 16px; }
+}
+
+/* Notice / callout blocks (raw HTML in content, like <aside>) */
+.lm-prose .notice {
+  font-size: 15px;
+  line-height: 1.65;
+  color: var(--muted);
+  background: var(--accent-glow);
+  border-left: 3px solid var(--pine);
+  border-radius: 0 8px 8px 0;
+  padding: 14px 18px;
+  margin: 1.6em 0;
+}
+.lm-prose .notice p:last-child { margin-bottom: 0; }
+.lm-prose .notice strong { color: var(--ink); }
+.lm-prose .notice--draft {
+  border-left-color: #b8860b;
+  background: rgba(184, 134, 11, 0.09);
+}
+
+/* ---- ⌘K fast-search overlay ---- */
+#fastSearch {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding-top: 15vh;
+  background: rgb(0 0 0 / 0.35);
+  backdrop-filter: blur(3px);
+  -webkit-backdrop-filter: blur(3px);
+}
+.fast-search-box {
+  width: 90%;
+  max-width: 540px;
+  background: var(--field-bg);
+  border: 1px solid var(--hair);
+  border-radius: 10px;
+  box-shadow: 0 20px 60px rgb(0 0 0 / 0.22);
+  overflow: hidden;
+}
+#searchInput {
+  width: 100%;
+  padding: 14px 18px;
+  font-family: var(--sans);
+  font-size: 16px;
+  color: var(--ink);
+  background: transparent;
+  border: none;
+  border-bottom: 1px solid var(--hair);
+  outline: none;
+}
+#searchInput::placeholder { color: var(--muted); }
+#searchResults { list-style: none; margin: 0; padding: 0; max-height: 340px; overflow-y: auto; }
+#searchResults li { border-bottom: 1px solid var(--hair); animation: srFadeIn 0.15s ease-out both; }
+#searchResults li:nth-child(2) { animation-delay: 0.02s; }
+#searchResults li:nth-child(3) { animation-delay: 0.04s; }
+#searchResults li:nth-child(4) { animation-delay: 0.06s; }
+#searchResults li:nth-child(5) { animation-delay: 0.08s; }
+#searchResults li:last-child { border-bottom: none; }
+#searchResults a { display: block; padding: 10px 18px; text-decoration: none; color: var(--ink); }
+#searchResults a:hover, #searchResults a:focus { background: var(--accent-glow); outline: none; }
+#searchResults .title { font-weight: 600; font-size: 15px; display: block; }
+#searchResults .meta { display: block; font-family: var(--mono); font-size: 11px; color: var(--muted); text-transform: uppercase; letter-spacing: 0.05em; margin-top: 3px; }
+#searchResults .desc { display: block; font-size: 13px; color: var(--muted); margin-top: 2px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.search-message { padding: 14px 18px; color: var(--muted); font-size: 14px; font-style: italic; list-style: none; }
+@keyframes srFadeIn { from { opacity: 0; transform: translateY(-4px); } to { opacity: 1; transform: none; } }
+
+
 /* Sagebrush — "Western" redesign (v11). Warm paper, dark bands, Spectral
    serif + IBM Plex Mono (self-hosted). Homepage uses bf- classes; inner
    pages reuse Pine's lm- markup re-skinned via the token overrides below. */
@@ -188,10 +1647,10 @@ a.bf-pub:hover img { transform: translateY(-3px); box-shadow: 0 16px 34px rgba(4
 }
 
 /* ============================================================
-   INNER PAGES — re-skin Pine's lm- component library.
-   Pine's minimal.css is tokenized with CSS variables; we load it
-   first (via min/head.html) then override the tokens here to the
-   Sagebrush palette + Spectral/IBM Plex, forced warm in all modes.
+   DESIGN TOKENS — the sole token definitions for the site.
+   The lm- component library above is tokenized with CSS variables;
+   these set them to the Sagebrush palette + Spectral/IBM Plex,
+   forced warm in all modes (light + dark map to the same values).
    ============================================================ */
 :root,
 :root[data-theme="light"],
@@ -200,7 +1659,7 @@ a.bf-pub:hover img { transform: translateY(-3px); box-shadow: 0 16px 34px rgba(4
   --ink: #292318;
   --pine: #2f5a43;
   --pine-deep: #274d39;
-  --muted: #8a8273;
+  --muted: #574f40;
   --hair: rgba(41, 35, 24, .14);
   --accent-line: rgba(47, 90, 67, .42);
   --accent-glow: rgba(47, 90, 67, .10);
@@ -216,12 +1675,80 @@ a.bf-pub:hover img { transform: translateY(-3px); box-shadow: 0 16px 34px rgba(4
 @media (prefers-color-scheme: dark) {
   :root:not([data-theme="light"]) {
     --paper: #efe8da; --ink: #292318; --pine: #2f5a43; --pine-deep: #274d39;
-    --muted: #8a8273; --hair: rgba(41, 35, 24, .14); --accent-line: rgba(47, 90, 67, .42);
+    --muted: #574f40; --hair: rgba(41, 35, 24, .14); --accent-line: rgba(47, 90, 67, .42);
     --accent-glow: rgba(47, 90, 67, .10); --field-bg: #ffffff; --btn-ink: #fdf8ee;
     --cover-shadow: rgba(41, 35, 24, .16); --cover-shadow-h: rgba(41, 35, 24, .26);
     --panel-green: #1d2a24;
   }
 }
+
+/* Screen-reader-only. accessibleFootnotes.js injects an <h2 class="sr">Footnotes</h2>
+   ahead of the notes; this hides it visually while keeping it for assistive tech. */
+.sr {
+  position: absolute;
+  width: 1px; height: 1px;
+  padding: 0; margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* Highlighter: a warm marker-gold band with soft ends that lets the ink read
+   through. box-decoration-break clones the stroke across wrapped lines. */
+mark {
+  background: linear-gradient(100deg,
+    rgba(214, 178, 92, 0) 0.15em,
+    rgba(214, 178, 92, 0.5) 0.35em,
+    rgba(214, 178, 92, 0.5) calc(100% - 0.35em),
+    rgba(214, 178, 92, 0) calc(100% - 0.15em));
+  color: inherit;
+  padding: 0.06em 0.05em;
+  border-radius: 1px;
+  -webkit-box-decoration-break: clone;
+  box-decoration-break: clone;
+}
+
+/* Collapsible detail blocks in prose (e.g. document transcripts): set off in a
+   recessed, tinted box at a smaller type size than the body. Scoped to .lm-prose
+   so it never touches the bookshelf's ISBN <details> toggles. */
+.lm-prose details {
+  margin: 30px 0;
+  padding: 2px 22px;
+  border: 1px solid var(--hair);
+  border-radius: 4px;
+  background: rgba(41, 35, 24, .035);
+}
+.lm-prose summary {
+  cursor: pointer;
+  list-style: none;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 14px 0;
+  font-family: var(--mono);
+  font-size: 12px;
+  letter-spacing: .06em;
+  text-transform: uppercase;
+  color: var(--pine);
+}
+.lm-prose summary::-webkit-details-marker { display: none; }
+.lm-prose summary::before {
+  content: "\25B8";
+  font-size: 10px;
+  line-height: 1;
+  transition: transform .15s ease;
+}
+.lm-prose details[open] summary::before { transform: rotate(90deg); }
+.lm-prose details[open] summary {
+  margin-bottom: 10px;
+  border-bottom: 1px solid var(--hair);
+}
+.lm-prose details > :not(summary) {
+  font-size: 15px;
+  line-height: 1.62;
+}
+.lm-prose details > :not(summary):last-child { margin-bottom: 18px; }
 
 /* Reading column for inner pages (baseof wraps content in .sb-main) */
 .bf-inner { background: var(--paper); color: var(--ink); font-family: var(--sans); }

--- a/themes/sagebrush/assets/stylesheets/sagebrush.css
+++ b/themes/sagebrush/assets/stylesheets/sagebrush.css
@@ -173,19 +173,20 @@ a { color: inherit; }
 .lm-bio a:hover { border-bottom-color: var(--pine); }
 
 .lm-social {
+  padding-top: 2rem;
   display: flex;
   flex-wrap: wrap;
   gap: 8px 18px;
   font-size: 15px;
-  color: var(--muted);
+  color: var(--bf-gold);
 }
 .lm-social a {
   text-decoration: none;
-  color: var(--muted);
+  color: var(--bf-gold);
   cursor: pointer;
   transition: color 0.15s ease;
 }
-.lm-social a:hover { color: var(--pine); }
+.lm-social a:hover { color: var(--bf-clay); text-decoration: underline; }
 
 /* ---- Sections ---- */
 .lm-section { padding: 56px 0 0; }
@@ -193,7 +194,7 @@ a { color: inherit; }
   font-family: var(--mono);
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: var(--muted);
+  color: var(--bf-gold);
   margin: 0 0 22px;
 }
 
@@ -290,7 +291,7 @@ a { color: inherit; }
   font-size: 16px;
   color: var(--muted);
   margin: 14px 0 22px;
-  max-width: 56ch;
+  /* max-width: 56ch; */
 }
 
 /* ---- Featured callout ---- */
@@ -1235,7 +1236,7 @@ a { color: inherit; }
   line-height: 1.55;
   color: var(--muted);
   margin: 16px 0 0;
-  max-width: 54ch;
+  /* max-width: 54ch; */
 }
 .lm-archive-controls {
   display: flex;

--- a/themes/sagebrush/layouts/404.html
+++ b/themes/sagebrush/layouts/404.html
@@ -1,0 +1,7 @@
+{{ define "main" }}
+<section class="lm-404">
+  <p class="lm-label">404</p>
+  <h1 class="lm-archive-title">Page not found</h1>
+  <p class="lm-archive-lead">That page has moved, been retired, or never existed. Try the <a href="/archive/">archive</a> or head back <a href="/">home</a>.</p>
+</section>
+{{ end }}

--- a/themes/sagebrush/layouts/_default/about.html
+++ b/themes/sagebrush/layouts/_default/about.html
@@ -1,0 +1,84 @@
+{{ define "main" }}
+<header class="lm-archive-head">
+  <h1 class="lm-archive-title">{{ .Title }}</h1>
+</header>
+
+<section class="lm-roles">
+  <div class="lm-role">
+    <h3 class="lm-role-title">Senior Developer / Scholar</h3>
+    <p class="lm-role-org">Roy Rosenzweig Center for History &amp; New Media</p>
+  </div>
+  <div class="lm-role">
+    <h3 class="lm-role-title">Adjunct Professor of History</h3>
+    <p class="lm-role-org">George Mason University</p>
+  </div>
+  <div class="lm-role">
+    <h3 class="lm-role-title">Affiliate Fellow</h3>
+    <p class="lm-role-org">Center for Great Plains Studies, University of Nebraska&ndash;Lincoln</p>
+  </div>
+</section>
+
+<div class="lm-prose lm-about-body">
+  {{ .Content }}
+</div>
+
+{{ $posts := where site.RegularPages "Section" "in" (slice "blog" "microblog") }}
+{{ $wordCount := 0 }}
+{{ range $posts }}{{ $wordCount = add $wordCount .WordCount }}{{ end }}
+{{ $postCount := len $posts }}
+{{ $firstYear := (index (last 1 $posts) 0).Date.Year }}
+{{ $yearsActive := sub now.Year $firstYear | add 1 }}
+
+<section class="lm-stats">
+  <div class="lm-stat">
+    <span class="lm-stat-num">{{ $yearsActive }}</span>
+    <span class="lm-stat-label">Years writing</span>
+  </div>
+  <div class="lm-stat">
+    <span class="lm-stat-num">{{ $postCount | lang.FormatNumberCustom 0 }}</span>
+    <span class="lm-stat-label">Posts</span>
+  </div>
+  <div class="lm-stat">
+    <span class="lm-stat-num">{{ div $wordCount 1000 | lang.FormatNumberCustom 0 }}k</span>
+    <span class="lm-stat-label">Words written</span>
+  </div>
+  <div class="lm-stat">
+    <span class="lm-stat-num">{{ len (where (where site.RegularPages "Section" "microblog") ".Params.external" "ne" nil) | lang.FormatNumberCustom 0 }}</span>
+    <span class="lm-stat-label">Links shared</span>
+  </div>
+  <div class="lm-stat">
+    <span class="lm-stat-num">{{ len site.Taxonomies.tags }}</span>
+    <span class="lm-stat-label">Topics</span>
+  </div>
+</section>
+
+<section class="lm-about-links">
+  <div class="lm-about-col">
+    <p class="lm-label">Connect</p>
+    <ul class="lm-link-list">
+      {{ with site.Params.Author.email }}<li><a class="lm-email-link" data-name="{{ index (split . "@") 0 }}" data-domain="{{ index (split . "@") 1 }}">Email</a></li>{{ end }}
+      {{ with site.Params.social.bluesky }}<li><a href="{{ . }}">Bluesky</a></li>{{ end }}
+      {{ with site.Params.social.mastodon }}<li><a href="{{ . }}" rel="me">Mastodon</a></li>{{ end }}
+      <li><a href="https://github.com/hepplerj">GitHub</a></li>
+      {{ with site.Params.social.linkedin }}<li><a href="{{ . }}">LinkedIn</a></li>{{ end }}
+      {{ with site.Params.social.microblog }}<li><a href="{{ . }}">Micro.blog</a></li>{{ end }}
+    </ul>
+  </div>
+  <div class="lm-about-col">
+    <p class="lm-label">Elsewhere</p>
+    <ul class="lm-link-list">
+      <li><a href="/blogroll/">Blogroll</a></li>
+      <li><a href="/courses/">Teaching</a></li>
+      <li><a href="/uses/">Uses</a></li>
+      <li><a href="https://www.tackandink.org/">Newsletter</a></li>
+    </ul>
+  </div>
+  <div class="lm-about-col">
+    <p class="lm-label">Feeds</p>
+    <ul class="lm-link-list">
+      <li><a href="/feed.xml">RSS</a></li>
+      <li><a href="/feed.json">JSON Feed</a></li>
+    </ul>
+  </div>
+</section>
+{{ end }}

--- a/themes/sagebrush/layouts/_default/about.html
+++ b/themes/sagebrush/layouts/_default/about.html
@@ -62,20 +62,24 @@
       <li><a href="https://github.com/hepplerj">GitHub</a></li>
       {{ with site.Params.social.linkedin }}<li><a href="{{ . }}">LinkedIn</a></li>{{ end }}
       {{ with site.Params.social.microblog }}<li><a href="{{ . }}">Micro.blog</a></li>{{ end }}
-    </ul>
-  </div>
-  <div class="lm-about-col">
-    <p class="lm-label">Elsewhere</p>
-    <ul class="lm-link-list">
-      <li><a href="/blogroll/">Blogroll</a></li>
-      <li><a href="/courses/">Teaching</a></li>
-      <li><a href="/uses/">Uses</a></li>
       <li><a href="https://www.tackandink.org/">Newsletter</a></li>
     </ul>
   </div>
   <div class="lm-about-col">
-    <p class="lm-label">Feeds</p>
+    <p class="lm-label">Slash Pages</p>
     <ul class="lm-link-list">
+      <li><a href="/now/">/now</a></li>
+      <li><a href="/nope/">/nope</a></li>
+      <li><a href="/uses/">/uses</a></li>
+      <li><a href="/blogroll/">/blogroll</a></li>
+    </ul>
+  </div>
+  <div class="lm-about-col">
+    <p class="lm-label">Pages + Feeds</p>
+    <ul class="lm-link-list">
+      <li><a href="/courses/">Teaching</a></li>
+      <li><a href="/office-hours/">Office Hours</a></li>
+      <li><a href="/norwegian/">Norwegian resources</a></li>
       <li><a href="/feed.xml">RSS</a></li>
       <li><a href="/feed.json">JSON Feed</a></li>
     </ul>

--- a/themes/sagebrush/layouts/_default/blogroll.html
+++ b/themes/sagebrush/layouts/_default/blogroll.html
@@ -1,0 +1,8 @@
+{{ define "main" }}
+<header class="lm-archive-head">
+  <h1 class="lm-archive-title">{{ .Title }}</h1>
+</header>
+<div class="lm-prose lm-blogroll lm-page-body">
+  {{ .Content }}
+</div>
+{{ end }}

--- a/themes/sagebrush/layouts/_default/digital-history.html
+++ b/themes/sagebrush/layouts/_default/digital-history.html
@@ -1,0 +1,23 @@
+{{ define "main" }}
+<header class="lm-archive-head">
+  <p class="lm-label">Digital &amp; public history</p>
+  <h1 class="lm-archive-title">Over a decade of building history on the web.</h1>
+  <div class="lm-archive-lead">{{ .Content }}</div>
+</header>
+
+<div class="lm-dh-grid">
+  {{ range hugo.Data.dh_projects }}
+  {{ $title := .title }}
+  <a href="{{ .url }}" class="lm-project-card{{ if .image }} lm-project-card-img{{ end }}" target="_blank" rel="noopener">
+    {{ with .image }}<img class="lm-project-thumb" src="/assets/images/{{ . }}" alt="{{ $title }}" loading="lazy" decoding="async">{{ end }}
+    <span class="lm-project-body">
+      <span class="lm-project-head">
+        <span class="lm-project-title">{{ .title }}</span>
+        <span class="lm-project-arrow">&nearr;</span>
+      </span>
+      <span class="lm-project-desc">{{ .desc }}</span>
+    </span>
+  </a>
+  {{ end }}
+</div>
+{{ end }}

--- a/themes/sagebrush/layouts/_default/list.html
+++ b/themes/sagebrush/layouts/_default/list.html
@@ -1,0 +1,18 @@
+{{ define "main" }}
+<header class="lm-archive-head">
+  <p class="lm-label">{{ .Section | humanize }}</p>
+  <h1 class="lm-archive-title">{{ .Title }}</h1>
+  {{ with .Content }}<div class="lm-archive-lead">{{ . }}</div>{{ end }}
+</header>
+
+{{ with .Pages }}
+<div class="lm-stream">
+  {{ range .ByDate.Reverse }}
+  <a href="{{ .RelPermalink }}" class="lm-row">
+    <span class="lm-row-title">{{ .Title }}</span>
+    <time class="lm-row-date" datetime="{{ .Date.Format "2006-01-02" }}">{{ .Date.Format "Jan 2, 2006" }}</time>
+  </a>
+  {{ end }}
+</div>
+{{ end }}
+{{ end }}

--- a/themes/sagebrush/layouts/_default/single.html
+++ b/themes/sagebrush/layouts/_default/single.html
@@ -1,0 +1,11 @@
+{{ define "main" }}
+<article class="lm-page">
+  <header class="lm-archive-head">
+    <h1 class="lm-archive-title">{{ .Title }}</h1>
+    {{ with .Description }}<p class="lm-archive-lead">{{ . }}</p>{{ end }}
+  </header>
+  <div class="lm-prose lm-page-body">
+    {{ .Content }}
+  </div>
+</article>
+{{ end }}

--- a/themes/sagebrush/layouts/archive/single.html
+++ b/themes/sagebrush/layouts/archive/single.html
@@ -1,0 +1,76 @@
+{{ define "main" }}
+<header class="lm-archive-head">
+  <p class="lm-label">Writing</p>
+  <h1 class="lm-archive-title">{{ .Title }}</h1>
+  <p class="lm-archive-lead">Longer essays, short notes, and quotations worth keeping — one stream you can filter and search.</p>
+</header>
+
+<div class="lm-archive-controls">
+  <div class="lm-chips" id="lmChips">
+    <button class="lm-chip on" data-filter="all">All <span class="lm-chip-n" id="lmCountAll"></span></button>
+    <button class="lm-chip" data-filter="essay">Essays <span class="lm-chip-n" id="lmCountEssay"></span></button>
+    <button class="lm-chip" data-filter="micro">Microblog <span class="lm-chip-n" id="lmCountMicro"></span></button>
+  </div>
+  <input type="search" class="lm-search" id="lmSearch" placeholder="Search titles…" aria-label="Search writing">
+</div>
+
+<p class="lm-archive-count" id="lmResultCount"></p>
+
+<div class="lm-archive-list" id="lmArchiveList">
+  {{ $blog := where site.RegularPages "Section" "blog" }}
+  {{ $micro := where site.RegularPages "Section" "microblog" }}
+  {{ $all := union $blog $micro }}
+  {{ range $all.ByDate.Reverse }}
+  {{ $type := cond (eq .Section "blog") "essay" "micro" }}
+  {{ $label := cond (eq .Section "blog") "Essay" "Microblog" }}
+  <a href="{{ .RelPermalink }}" class="lm-archive-row" data-type="{{ $type }}" data-title="{{ .Title | lower }}">
+    <span class="lm-archive-row-title">{{ .Title }}{{ with .Params.external }} <span class="lm-archive-row-source">{{ . | replaceRE "^https?://(www\\.)?" "" | replaceRE "/.*$" "" }}</span>{{ end }}</span>
+    <span class="lm-archive-row-meta">
+      <span class="lm-type lm-type-{{ $type }}">{{ $label }}</span>
+      <time class="lm-archive-date" datetime="{{ .Date.Format "2006-01-02" }}">{{ .Date.Format "Jan 2, 2006" }}</time>
+    </span>
+  </a>
+  {{ end }}
+</div>
+
+<p class="lm-archive-empty" id="lmArchiveEmpty" style="display:none">No posts match your search.</p>
+
+<script>
+  (function () {
+    var chips = document.querySelectorAll('#lmChips .lm-chip');
+    var search = document.getElementById('lmSearch');
+    var rows = document.querySelectorAll('.lm-archive-row');
+    var resultCount = document.getElementById('lmResultCount');
+    var empty = document.getElementById('lmArchiveEmpty');
+    var filter = 'all', query = '';
+
+    var counts = { all: rows.length, essay: 0, micro: 0 };
+    rows.forEach(function (r) { counts[r.dataset.type]++; });
+    document.getElementById('lmCountAll').textContent = counts.all;
+    document.getElementById('lmCountEssay').textContent = counts.essay;
+    document.getElementById('lmCountMicro').textContent = counts.micro;
+
+    function update() {
+      var visible = 0, q = query.toLowerCase();
+      rows.forEach(function (row) {
+        var show = (filter === 'all' || row.dataset.type === filter) && (!q || row.dataset.title.includes(q));
+        row.style.display = show ? '' : 'none';
+        if (show) visible++;
+      });
+      resultCount.textContent = visible + ' post' + (visible !== 1 ? 's' : '');
+      empty.style.display = visible === 0 ? '' : 'none';
+    }
+
+    chips.forEach(function (chip) {
+      chip.addEventListener('click', function () {
+        chips.forEach(function (c) { c.classList.remove('on'); });
+        chip.classList.add('on');
+        filter = chip.dataset.filter;
+        update();
+      });
+    });
+    search.addEventListener('input', function () { query = search.value; update(); });
+    update();
+  })();
+</script>
+{{ end }}

--- a/themes/sagebrush/layouts/blog/single.html
+++ b/themes/sagebrush/layouts/blog/single.html
@@ -1,0 +1,83 @@
+{{ define "main" }}
+<article class="lm-article h-entry">
+  <header class="lm-article-head">
+    <p class="lm-label">Essay</p>
+    <h1 class="lm-article-title p-name">{{ .Title }}</h1>
+    {{ with .Params.lede }}<p class="lm-article-lede">{{ . }}</p>{{ end }}
+    <div class="lm-article-meta">
+      <time class="dt-published" datetime="{{ .Date.Format "2006-01-02" }}">{{ .Date.Format "January 2, 2006" }}</time>
+      <span class="lm-dot-sep">·</span>
+      <span class="p-author">Jason A. Heppler</span>
+      <span class="lm-dot-sep">·</span>
+      <span>{{ .ReadingTime }} min read</span>
+    </div>
+  </header>
+
+  {{ with .Params.image }}
+  <figure class="lm-article-lead">
+    <img src="/assets/images/{{ . }}" alt="{{ $.Title }}" loading="lazy" decoding="async">
+  </figure>
+  {{ end }}
+
+  <div class="lm-prose e-content">
+    {{ .Content }}
+  </div>
+
+  <div class="lm-article-footer">
+    <p class="lm-post-note">This is an <a href="/archive/">essay</a> — a longer piece of writing on a topic I've been thinking about.</p>
+    <p class="lm-post-meta">
+      {{ partial "min/carbon-badge.html" . }}
+      {{ with .Params.tags }}<span class="lm-dot-sep">·</span>{{ range $i, $t := . }}{{ if $i }}<span class="lm-dot-sep">·</span>{{ end }}<a href="/tags/{{ $t | urlize }}/">{{ $t | humanize }}</a>{{ end }}{{ end }}
+    </p>
+  </div>
+
+  {{ partial "min/author-card.html" . }}
+
+  {{ $pages := where site.RegularPages "Section" "blog" }}
+  {{ $prev := $pages.Prev . }}
+  {{ $next := $pages.Next . }}
+  {{ if or $prev $next }}
+  <nav class="lm-prevnext">
+    {{ with $prev }}
+    <a href="{{ .RelPermalink }}" class="lm-prevnext-item">
+      <span class="lm-prevnext-label">&larr; Previous</span>
+      <span class="lm-prevnext-title">{{ .Title }}</span>
+    </a>
+    {{ else }}<span></span>{{ end }}
+    {{ with $next }}
+    <a href="{{ .RelPermalink }}" class="lm-prevnext-item lm-prevnext-next">
+      <span class="lm-prevnext-label">Next &rarr;</span>
+      <span class="lm-prevnext-title">{{ .Title }}</span>
+    </a>
+    {{ else }}<span></span>{{ end }}
+  </nav>
+  {{ end }}
+
+  {{ $pool := where (where site.RegularPages "Section" "in" (slice "blog" "microblog")) "RelPermalink" "ne" .RelPermalink }}
+  {{ $related := slice }}
+  {{ with .Params.tags }}
+    {{ $related = (where $pool ".Params.tags" "intersect" .).ByDate.Reverse }}
+  {{ end }}
+  {{ $related = first 3 $related }}
+  {{ if lt (len $related) 3 }}
+    {{ range first 8 $pool.ByDate.Reverse }}
+      {{ if and (lt (len $related) 3) (not (in $related .)) }}{{ $related = $related | append . }}{{ end }}
+    {{ end }}
+  {{ end }}
+  {{ with $related }}
+  <section class="lm-related">
+    <p class="lm-label">Related reading</p>
+    <div class="lm-related-grid">
+      {{ range . }}
+      <a href="{{ .RelPermalink }}" class="lm-related-item">
+        <span class="lm-related-title">{{ .Title }}</span>
+        <time class="lm-related-date" datetime="{{ .Date.Format "2006-01-02" }}">{{ .Date.Format "Jan 2006" }}</time>
+      </a>
+      {{ end }}
+    </div>
+  </section>
+  {{ end }}
+
+  <a href="https://brid.gy/publish/bluesky" class="u-syndication" hidden></a>
+</article>
+{{ end }}

--- a/themes/sagebrush/layouts/books/list.html
+++ b/themes/sagebrush/layouts/books/list.html
@@ -1,0 +1,105 @@
+{{ define "main" }}
+<header class="lm-archive-head">
+  <p class="lm-label">Reading</p>
+  <h1 class="lm-archive-title">Bookshelf</h1>
+  <p class="lm-archive-lead">What I'm reading and have read. For older reading logs, see <a href="https://www.librarything.com/profile/hepplerj">LibraryThing</a>.</p>
+</header>
+
+{{ $reading := where (where site.RegularPages "Section" "books") ".Params.categories" "intersect" (slice "reading") }}
+{{ with $reading }}
+<section class="lm-section">
+  <p class="lm-label">Currently reading</p>
+  <div class="lm-shelf">
+    {{ range . }}
+    <div class="lm-shelf-entry">
+      <div class="lm-shelf-row">
+        <span class="lm-shelf-info">
+          <span class="lm-shelf-title">{{ .Title }}</span>
+          <span class="lm-shelf-meta">{{ .Params.author }}{{ with .Params.pub_year }} · {{ . }}{{ end }}</span>
+        </span>
+      </div>
+    </div>
+    {{ end }}
+  </div>
+</section>
+{{ end }}
+
+{{ $allBooks := where (where site.RegularPages "Section" "books") ".Date" "ge" (time "2018-01-01") }}
+<section class="lm-section">
+  <div class="lm-archive-controls">
+    <div class="lm-chips" id="shelfChips">
+      {{ $years := slice }}
+      {{ range $allBooks }}{{ $y := .Date.Format "2006" }}{{ if not (in $years $y) }}{{ $years = $years | append $y }}{{ end }}{{ end }}
+      {{ range sort $years "value" "desc" }}
+      <button class="lm-chip{{ if eq . (now.Format "2006") }} on{{ end }}" data-shelf="{{ . }}">{{ . }}</button>
+      {{ end }}
+      <button class="lm-chip" data-shelf="all">All</button>
+    </div>
+  </div>
+  <p class="lm-archive-count" id="shelfCount"></p>
+
+  <div class="lm-shelf" id="shelfList">
+    {{ range $allBooks.ByDate.Reverse }}
+    {{ if not (in .Params.categories "reading") }}
+    <div class="lm-shelf-entry" data-year="{{ .Date.Format "2006" }}">
+      {{ $reviewed := "" }}{{ if .Params.reviewed }}{{ $reviewed = .Permalink }}{{ with .Params.review_url }}{{ $reviewed = . }}{{ end }}{{ end }}
+      {{ if .Params.isbn }}
+      <details class="lm-shelf-details">
+        <summary class="lm-shelf-row">
+          <span class="lm-shelf-info">
+            <span class="lm-shelf-title">{{ with $reviewed }}<a href="{{ . }}" class="lm-reviewed">Reviewed</a> {{ end }}{{ .Title }}</span>
+            <span class="lm-shelf-meta">{{ .Params.author }}{{ with .Params.pub_year }} · {{ . }}{{ end }}</span>
+          </span>
+          <span class="lm-shelf-year">{{ .Date.Format "2006" }}</span>
+        </summary>
+        <div class="lm-shelf-expanded">
+          <span class="lm-shelf-isbn">ISBN {{ .Params.isbn }}</span>
+          <span class="lm-shelf-links">
+            <a href="https://worldcat.org/isbn/{{ .Params.isbn }}">WorldCat</a>
+            <a href="https://openlibrary.org/isbn/{{ .Params.isbn }}">Open Library</a>
+            <a href="https://bookshop.org/beta-search?keywords={{ .Params.isbn }}">Bookshop</a>
+          </span>
+          {{ with .Params.publisher }}<span class="lm-shelf-publisher">{{ . }}</span>{{ end }}
+        </div>
+      </details>
+      {{ else }}
+      <div class="lm-shelf-row">
+        <span class="lm-shelf-info">
+          <span class="lm-shelf-title">{{ with $reviewed }}<a href="{{ . }}" class="lm-reviewed">Reviewed</a> {{ end }}{{ .Title }}</span>
+          <span class="lm-shelf-meta">{{ .Params.author }}{{ with .Params.pub_year }} · {{ . }}{{ end }}</span>
+        </span>
+        <span class="lm-shelf-year">{{ .Date.Format "2006" }}</span>
+      </div>
+      {{ end }}
+    </div>
+    {{ end }}
+    {{ end }}
+  </div>
+</section>
+
+<script>
+  (function () {
+    var chips = document.querySelectorAll('#shelfChips .lm-chip');
+    var entries = document.querySelectorAll('#shelfList .lm-shelf-entry');
+    var count = document.getElementById('shelfCount');
+    function apply(shelf) {
+      var visible = 0;
+      entries.forEach(function (e) {
+        var show = shelf === 'all' || e.dataset.year === shelf;
+        e.style.display = show ? '' : 'none';
+        if (show) visible++;
+      });
+      count.textContent = visible + ' book' + (visible !== 1 ? 's' : '') + (shelf === 'all' ? '' : ' in ' + shelf);
+    }
+    chips.forEach(function (chip) {
+      chip.addEventListener('click', function () {
+        chips.forEach(function (c) { c.classList.remove('on'); });
+        chip.classList.add('on');
+        apply(chip.dataset.shelf);
+      });
+    });
+    var active = document.querySelector('#shelfChips .lm-chip.on');
+    apply(active ? active.dataset.shelf : 'all');
+  })();
+</script>
+{{ end }}

--- a/themes/sagebrush/layouts/courses/list.html
+++ b/themes/sagebrush/layouts/courses/list.html
@@ -1,0 +1,9 @@
+{{ define "main" }}
+<header class="lm-archive-head">
+  <p class="lm-label">Teaching</p>
+  <h1 class="lm-archive-title">{{ .Title }}</h1>
+</header>
+<div class="lm-prose lm-page-body">
+  {{ .Content }}
+</div>
+{{ end }}

--- a/themes/sagebrush/layouts/courses/single.html
+++ b/themes/sagebrush/layouts/courses/single.html
@@ -1,0 +1,32 @@
+{{ define "main" }}
+<a href="/courses/" class="lm-breadcrumb">&larr; Teaching</a>
+
+<header class="lm-archive-head">
+  {{ with .Params.semester }}<p class="lm-label">{{ . }} {{ $.Params.year }}</p>{{ end }}
+  <h1 class="lm-archive-title">{{ .Title }}</h1>
+</header>
+
+{{ with .Params.number }}
+<aside class="lm-course-meta">
+  <p>
+    <strong>Course:</strong>
+    {{ with $.Params.site }}<a href="{{ . }}">{{ $.Params.number }}</a>{{ else }}{{ $.Params.number }}{{ end }}.
+    {{ $.Params.semester }} {{ $.Params.year }}.
+    {{ $.Params.department }}, {{ $.Params.university }}.
+  </p>
+  {{ with $.Params.instructor }}
+  <p>
+    <strong>Instructor:</strong>
+    {{ with $.Params.instructorurl }}<a href="{{ . }}">{{ $.Params.instructor }}</a>{{ else }}{{ $.Params.instructor }}{{ end }}
+    {{ with $.Params.email }}&lt;<a href="mailto:{{ . }}">{{ . }}</a>&gt;{{ end }}.
+    {{ with $.Params.office }}Office: {{ . }}.{{ end }}
+    {{ with $.Params.officehours }}Office hours: {{ . }}.{{ end }}
+  </p>
+  {{ end }}
+</aside>
+{{ end }}
+
+<div class="lm-prose lm-page-body">
+  {{ .Content }}
+</div>
+{{ end }}

--- a/themes/sagebrush/layouts/index.html
+++ b/themes/sagebrush/layouts/index.html
@@ -86,6 +86,14 @@
         <p class="bf-meet-lead"><span class="bf-name">Jason A. Heppler</span> is a historian of the North American West and Great Plains, and a builder of digital history.</p>
         <p class="bf-meet-body">Senior developer/scholar at the Roy Rosenzweig Center for History and New Media and an Affiliate Fellow at the Center for Great Plains Studies, University of Nebraska–Lincoln.</p>
         <a href="/about/" class="bf-textlink">Read more &rarr;</a>
+        <div class="lm-social">
+        <a data-name="jason" data-domain="jasonheppler.org">Email</a>
+        {{ with site.Params.social.bluesky }}<a href="{{ . }}">Bluesky</a>{{ end }}
+        {{ with site.Params.social.microblog }}<a href="{{ . }}">micro.blog</a>{{ end }}
+        {{ with site.Params.social.mastodon }}<a href="{{ . }}" rel="me">Mastodon</a>{{ end }}
+        {{ with site.Params.social.github }}<a href="{{ . }}">GitHub</a>{{ end }}
+        {{ with site.Params.social.buymeacoffee }}<a href="{{ . }}">Buy Me a Coffee</a>{{ end }}
+        </div>
       </div>
     </div>
   </section>

--- a/themes/sagebrush/layouts/lab/minimal-archive.html
+++ b/themes/sagebrush/layouts/lab/minimal-archive.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  {{ partial "lab/head.html" (dict "title" "Writing — minimal prototype") }}
+</head>
+<body>
+  <div class="lm-wrap">
+
+    {{ partial "lab/topbar.html" . }}
+
+    <header class="lm-archive-head">
+      <p class="lm-label">Writing</p>
+      <h1 class="lm-archive-title">Essays, notes &amp; commonplace</h1>
+      <p class="lm-archive-lead">Longer essays, short notes, and quotations worth keeping — one stream you can filter and search.</p>
+    </header>
+
+    <div class="lm-archive-controls">
+      <div class="lm-chips" id="lmChips">
+        <button class="lm-chip on" data-filter="all">All <span class="lm-chip-n" id="lmCountAll"></span></button>
+        <button class="lm-chip" data-filter="essay">Essays <span class="lm-chip-n" id="lmCountEssay"></span></button>
+        <button class="lm-chip" data-filter="note">Notes <span class="lm-chip-n" id="lmCountNote"></span></button>
+        <button class="lm-chip" data-filter="link">Commonplace <span class="lm-chip-n" id="lmCountLink"></span></button>
+      </div>
+      <input type="search" class="lm-search" id="lmSearch" placeholder="Search titles…" aria-label="Search writing">
+    </div>
+
+    <p class="lm-archive-count" id="lmResultCount"></p>
+
+    <div class="lm-archive-list" id="lmArchiveList">
+      {{ $blog := where site.RegularPages "Section" "blog" }}
+      {{ $notes := where site.RegularPages "Section" "notes" }}
+      {{ $links := where site.RegularPages "Section" "links" }}
+      {{ $all := union $blog (union $notes $links) }}
+      {{ range $all.ByDate.Reverse }}
+      {{ $type := cond (eq .Section "blog") "essay" (cond (eq .Section "notes") "note" "link") }}
+      {{ $label := cond (eq .Section "blog") "Essay" (cond (eq .Section "notes") "Note" "Commonplace") }}
+      <a href="{{ .RelPermalink }}" class="lm-archive-row" data-type="{{ $type }}" data-title="{{ .Title | lower }}">
+        <span class="lm-archive-row-title">{{ .Title }}{{ if and (eq .Section "links") .Params.external }} <span class="lm-archive-row-source">{{ .Params.external | replaceRE "^https?://(www\\.)?" "" | replaceRE "/.*$" "" }}</span>{{ end }}</span>
+        <span class="lm-archive-row-meta">
+          <span class="lm-type lm-type-{{ $type }}">{{ $label }}</span>
+          <time class="lm-archive-date" datetime="{{ .Date.Format "2006-01-02" }}">{{ .Date.Format "Jan 2, 2006" }}</time>
+        </span>
+      </a>
+      {{ end }}
+    </div>
+
+    <p class="lm-archive-empty" id="lmArchiveEmpty" style="display:none">No posts match your search.</p>
+
+    {{ partial "lab/site-footer.html" . }}
+
+  </div>
+
+  {{ partial "lab/scripts.html" . }}
+  <script>
+    (function () {
+      var chips = document.querySelectorAll('#lmChips .lm-chip');
+      var search = document.getElementById('lmSearch');
+      var rows = document.querySelectorAll('.lm-archive-row');
+      var resultCount = document.getElementById('lmResultCount');
+      var empty = document.getElementById('lmArchiveEmpty');
+      var filter = 'all', query = '';
+
+      var counts = { all: rows.length, essay: 0, note: 0, link: 0 };
+      rows.forEach(function (r) { counts[r.dataset.type]++; });
+      document.getElementById('lmCountAll').textContent = counts.all;
+      document.getElementById('lmCountEssay').textContent = counts.essay;
+      document.getElementById('lmCountNote').textContent = counts.note;
+      document.getElementById('lmCountLink').textContent = counts.link;
+
+      function update() {
+        var visible = 0, q = query.toLowerCase();
+        rows.forEach(function (row) {
+          var show = (filter === 'all' || row.dataset.type === filter) && (!q || row.dataset.title.includes(q));
+          row.style.display = show ? '' : 'none';
+          if (show) visible++;
+        });
+        resultCount.textContent = visible + ' post' + (visible !== 1 ? 's' : '');
+        empty.style.display = visible === 0 ? '' : 'none';
+      }
+
+      chips.forEach(function (chip) {
+        chip.addEventListener('click', function () {
+          chips.forEach(function (c) { c.classList.remove('on'); });
+          chip.classList.add('on');
+          filter = chip.dataset.filter;
+          update();
+        });
+      });
+      search.addEventListener('input', function () { query = search.value; update(); });
+      update();
+    })();
+  </script>
+</body>
+</html>

--- a/themes/sagebrush/layouts/lab/minimal-post.html
+++ b/themes/sagebrush/layouts/lab/minimal-post.html
@@ -1,0 +1,112 @@
+<!DOCTYPE html>
+<html lang="en">
+{{ $p := site.GetPage .Params.preview }}
+<head>
+  {{ partial "lab/head.html" (dict "title" (printf "%s — minimal prototype" $p.Title)) }}
+</head>
+<body>
+  <div class="lm-wrap">
+
+    {{ partial "lab/topbar.html" . }}
+
+    {{ with $p }}
+    <article class="lm-article">
+      <header class="lm-article-head">
+        <p class="lm-label">Essay</p>
+        <h1 class="lm-article-title">{{ .Title }}</h1>
+        {{ with .Params.lede }}<p class="lm-article-lede">{{ . }}</p>{{ end }}
+        <div class="lm-article-meta">
+          <time datetime="{{ .Date.Format "2006-01-02" }}">{{ .Date.Format "January 2, 2006" }}</time>
+          <span class="lm-dot-sep">·</span>
+          <span>Jason A. Heppler</span>
+          <span class="lm-dot-sep">·</span>
+          <span>{{ .ReadingTime }} min read</span>
+        </div>
+      </header>
+
+      {{ with .Params.image }}
+      <figure class="lm-article-lead">
+        <img src="/assets/images/{{ . }}" alt="{{ $p.Title }}" loading="lazy" decoding="async">
+      </figure>
+      {{ end }}
+
+      <div class="lm-prose">
+        {{ .Content }}
+      </div>
+
+      <div class="lm-article-footer">
+        <p class="lm-post-note">This is an <a href="/archive/">essay</a> — a longer piece of writing on a topic I've been thinking about.</p>
+        {{ with .Params.tags }}
+        <p class="lm-tags">
+          {{ range $i, $t := . }}{{ if $i }}<span class="lm-dot-sep">·</span>{{ end }}<a href="/tags/{{ $t | urlize }}/">{{ $t | humanize }}</a>{{ end }}
+        </p>
+        {{ end }}
+      </div>
+
+      <aside class="lm-author">
+        <img src="/assets/images/portrait.webp" alt="Jason A. Heppler" width="56" height="56">
+        <div class="lm-author-text">
+          <span class="lm-author-name">Jason A. Heppler</span>
+          <span class="lm-author-role">Environmental &amp; digital historian</span>
+        </div>
+        <div class="lm-author-links">
+          {{ with site.Params.social.bluesky }}<a href="{{ . }}">Bluesky</a>{{ end }}
+          {{ with site.Params.social.mastodon }}<a href="{{ . }}" rel="me">Mastodon</a>{{ end }}
+          {{ with site.Params.social.github }}<a href="{{ . }}">GitHub</a>{{ end }}
+        </div>
+      </aside>
+
+      {{ $siblings := where site.RegularPages "Section" "blog" }}
+      {{ $prev := $siblings.Prev $p }}
+      {{ $next := $siblings.Next $p }}
+      {{ if or $prev $next }}
+      <nav class="lm-prevnext">
+        {{ with $prev }}
+        <a href="{{ .RelPermalink }}" class="lm-prevnext-item">
+          <span class="lm-prevnext-label">&larr; Previous</span>
+          <span class="lm-prevnext-title">{{ .Title }}</span>
+        </a>
+        {{ else }}<span></span>{{ end }}
+        {{ with $next }}
+        <a href="{{ .RelPermalink }}" class="lm-prevnext-item lm-prevnext-next">
+          <span class="lm-prevnext-label">Next &rarr;</span>
+          <span class="lm-prevnext-title">{{ .Title }}</span>
+        </a>
+        {{ else }}<span></span>{{ end }}
+      </nav>
+      {{ end }}
+
+      {{ $pool := where (where site.RegularPages "Section" "in" (slice "blog" "notes")) "RelPermalink" "ne" $p.RelPermalink }}
+      {{ $related := slice }}
+      {{ with $p.Params.tags }}
+        {{ $related = (where $pool ".Params.tags" "intersect" .).ByDate.Reverse }}
+      {{ end }}
+      {{ $related = first 3 $related }}
+      {{ if lt (len $related) 3 }}
+        {{ range first 8 $pool.ByDate.Reverse }}
+          {{ if and (lt (len $related) 3) (not (in $related .)) }}{{ $related = $related | append . }}{{ end }}
+        {{ end }}
+      {{ end }}
+      {{ with $related }}
+      <section class="lm-related">
+        <p class="lm-label">Related reading</p>
+        <div class="lm-related-grid">
+          {{ range . }}
+          <a href="{{ .RelPermalink }}" class="lm-related-item">
+            <span class="lm-related-title">{{ .Title }}</span>
+            <time class="lm-related-date" datetime="{{ .Date.Format "2006-01-02" }}">{{ .Date.Format "Jan 2006" }}</time>
+          </a>
+          {{ end }}
+        </div>
+      </section>
+      {{ end }}
+    </article>
+    {{ end }}
+
+    {{ partial "lab/site-footer.html" . }}
+
+  </div>
+
+  {{ partial "lab/scripts.html" . }}
+</body>
+</html>

--- a/themes/sagebrush/layouts/lab/minimal.html
+++ b/themes/sagebrush/layouts/lab/minimal.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  {{ partial "lab/head.html" (dict "title" "Jason A. Heppler — minimal prototype") }}
+</head>
+<body>
+  <div class="lm-wrap">
+
+    {{ partial "lab/topbar.html" . }}
+
+    <section class="lm-intro">
+      <div class="lm-intro-head">
+        <figure class="lm-portrait">
+          <img src="/assets/images/portrait.webp" alt="Jason A. Heppler" width="88" height="88" loading="eager">
+          <figcaption>Photo by <a href="https://www.johnlegg.org/academic-photography">John Legg</a></figcaption>
+        </figure>
+        <h1>Historian of land and environmental politics in the North American West.</h1>
+      </div>
+      <p class="lm-bio">Hi, I'm Jason A. Heppler, a historian writing about the twentieth century North American West, Great Plains, and Canadian Prairies. I'm the senior developer/scholar at the <a href="https://rrchnm.org">Roy Rosenzweig Center for History and New Media</a> and an Affiliate Fellow at the <a href="https://www.unl.edu/plains/">Center for Great Plains Studies</a> at the University of Nebraska-Lincoln.</p>
+      <div class="lm-social">
+        <a class="lm-email-link" data-name="jason" data-domain="jasonheppler.org">Email</a>
+        {{ with site.Params.social.bluesky }}<a href="{{ . }}">Bluesky</a>{{ end }}
+        {{ with site.Params.social.mastodon }}<a href="{{ . }}" rel="me">Mastodon</a>{{ end }}
+        {{ with site.Params.social.github }}<a href="{{ . }}">GitHub</a>{{ end }}
+      </div>
+    </section>
+
+    {{ $writing := first 7 (where site.RegularPages "Section" "in" (slice "blog" "notes")).ByDate.Reverse }}
+    {{ with $writing }}
+    <section class="lm-section">
+      <p class="lm-label">Recent writing</p>
+      <div class="lm-stream">
+        {{ range . }}
+        <a href="{{ .RelPermalink }}" class="lm-row">
+          <span class="lm-row-title">{{ .Title }}</span>
+          <time class="lm-row-date" datetime="{{ .Date.Format "2006-01-02" }}">{{ .Date.Format "Jan 2, 2006" }}</time>
+        </a>
+        {{ end }}
+      </div>
+    </section>
+    {{ end }}
+
+    {{ $books := (where (where site.RegularPages "Section" "publications") ".Params.image" "ne" nil).ByDate.Reverse }}
+    {{ with $books }}
+    <section class="lm-section lm-books">
+      <p class="lm-label">Books</p>
+      <div class="lm-book-grid">
+        {{ range . }}
+        <a href="{{ .RelPermalink }}" class="lm-book">
+          <img class="lm-book-cover" src="/assets/images/{{ .Params.image }}" alt="{{ .Title }}" loading="lazy" decoding="async">
+          <span class="lm-book-title">{{ .Title }}</span>
+          <span class="lm-book-meta">{{ with .Params.publisher }}{{ . }}{{ end }}{{ with .Params.year }} · {{ . }}{{ end }}</span>
+        </a>
+        {{ end }}
+      </div>
+      <a href="/publications/" class="lm-more">All publications &rarr;</a>
+    </section>
+    {{ end }}
+
+    {{ partial "lab/site-footer.html" . }}
+
+  </div>
+
+  {{ partial "lab/scripts.html" . }}
+</body>
+</html>

--- a/themes/sagebrush/layouts/microblog/list.html
+++ b/themes/sagebrush/layouts/microblog/list.html
@@ -1,0 +1,39 @@
+{{ define "main" }}
+<header class="lm-archive-head">
+  <p class="lm-label">Microblog</p>
+  <h1 class="lm-archive-title">{{ .Title }}</h1>
+  {{ with .Content }}<div class="lm-archive-lead">{{ . }}</div>{{ end }}
+</header>
+
+{{ $paginator := .Paginate (.Pages.ByDate.Reverse) 10 }}
+
+<div class="lm-mb-list">
+  {{ range $paginator.Pages }}
+  <article class="lm-mb-post h-entry">
+    <header class="lm-mb-head">
+      <h2 class="lm-mb-title p-name"><a href="{{ .RelPermalink }}">{{ .Title }}</a></h2>
+      <a href="{{ .RelPermalink }}" class="lm-mb-date"><time class="dt-published" datetime="{{ .Date.Format "2006-01-02" }}">{{ .Date.Format "Jan 2, 2006" }}</time></a>
+    </header>
+    {{/* Rewrite bundle-relative image paths to absolute so they resolve off /microblog/ too. */}}
+    {{ $body := .Content | replaceRE `(src|data-microblog-lightbox)="([^/h][^"]*\.(?:webp|png|jpe?g|gif|svg))"` (printf `${1}="%s${2}"` .RelPermalink) }}
+    <div class="lm-mb-body lm-prose e-content">
+      {{ $body | safeHTML }}
+      {{ with .Params.external }}
+      <p class="lm-link-out"><a class="u-bookmark-of" href="{{ . }}">Visit link &rarr;</a></p>
+      {{ end }}
+    </div>
+    {{ with .Params.tags }}
+    <p class="lm-mb-tags">{{ range $i, $t := . }}{{ if $i }}<span class="lm-dot-sep">·</span>{{ end }}<a href="/tags/{{ $t | urlize }}/">{{ $t | humanize }}</a>{{ end }}</p>
+    {{ end }}
+  </article>
+  {{ end }}
+</div>
+
+{{ if gt $paginator.TotalPages 1 }}
+<nav class="lm-pager" aria-label="Microblog pages">
+  {{ if $paginator.HasPrev }}<a href="{{ $paginator.Prev.URL }}" class="lm-pager-link">&larr; Newer</a>{{ else }}<span class="lm-pager-link lm-pager-off">&larr; Newer</span>{{ end }}
+  <span class="lm-pager-count">{{ $paginator.PageNumber }} / {{ $paginator.TotalPages }}</span>
+  {{ if $paginator.HasNext }}<a href="{{ $paginator.Next.URL }}" class="lm-pager-link">Older &rarr;</a>{{ else }}<span class="lm-pager-link lm-pager-off">Older &rarr;</span>{{ end }}
+</nav>
+{{ end }}
+{{ end }}

--- a/themes/sagebrush/layouts/microblog/single.html
+++ b/themes/sagebrush/layouts/microblog/single.html
@@ -1,0 +1,29 @@
+{{ define "main" }}
+<article class="lm-article h-entry">
+  <header class="lm-article-head">
+    <div class="lm-mb-single-head">
+      <h1 class="lm-article-title p-name">{{ .Title }}</h1>
+      <span class="lm-mb-date"><time class="dt-published" datetime="{{ .Date.Format "2006-01-02" }}">{{ .Date.Format "January 2, 2006" }}</time></span>
+    </div>
+  </header>
+
+  <div class="lm-prose e-content">
+    {{ .Content }}
+    {{ with .Params.external }}
+    <p class="lm-link-out"><a class="u-bookmark-of" href="{{ . }}">Visit link &rarr;</a></p>
+    {{ end }}
+  </div>
+
+  <div class="lm-article-footer">
+    <p class="lm-post-note">This is a <a href="/archive/">microblog</a> post — a short note, observation, or link worth keeping.</p>
+    <p class="lm-post-meta">
+      {{ partial "min/carbon-badge.html" . }}
+      {{ with .Params.tags }}<span class="lm-dot-sep">·</span>{{ range $i, $t := . }}{{ if $i }}<span class="lm-dot-sep">·</span>{{ end }}<a href="/tags/{{ $t | urlize }}/">{{ $t | humanize }}</a>{{ end }}{{ end }}
+    </p>
+  </div>
+
+  {{ partial "min/author-card.html" . }}
+
+  <a href="https://brid.gy/publish/bluesky" class="u-syndication" hidden></a>
+</article>
+{{ end }}

--- a/themes/sagebrush/layouts/partials/lab/head.html
+++ b/themes/sagebrush/layouts/partials/lab/head.html
@@ -1,0 +1,15 @@
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="robots" content="noindex">
+<title>{{ .title }}</title>
+{{ $css := resources.Get "stylesheets/sagebrush.css" | resources.Minify | resources.Fingerprint "sha512" }}
+<link rel="stylesheet" href="{{ $css.RelPermalink }}">
+
+<script>
+  (function () {
+    var mode = localStorage.getItem('lm-theme-mode') || 'auto';
+    var root = document.documentElement;
+    root.setAttribute('data-mode', mode);
+    if (mode === 'light' || mode === 'dark') root.setAttribute('data-theme', mode);
+  })();
+</script>

--- a/themes/sagebrush/layouts/partials/lab/scripts.html
+++ b/themes/sagebrush/layouts/partials/lab/scripts.html
@@ -1,0 +1,23 @@
+<script>
+  document.querySelectorAll('.lm-email-link').forEach(function (el) {
+    el.addEventListener('click', function () {
+      var addr = el.dataset.name + '@' + el.dataset.domain;
+      window.location.href = 'mailto:' + addr;
+    });
+  });
+
+  (function () {
+    var root = document.documentElement;
+    var btn = document.querySelector('.lm-theme');
+    if (!btn) return;
+    var order = ['auto', 'light', 'dark'];
+    btn.addEventListener('click', function () {
+      var cur = root.getAttribute('data-mode') || 'auto';
+      var next = order[(order.indexOf(cur) + 1) % order.length];
+      root.setAttribute('data-mode', next);
+      if (next === 'auto') root.removeAttribute('data-theme');
+      else root.setAttribute('data-theme', next);
+      try { localStorage.setItem('lm-theme-mode', next); } catch (e) {}
+    });
+  })();
+</script>

--- a/themes/sagebrush/layouts/partials/lab/site-footer.html
+++ b/themes/sagebrush/layouts/partials/lab/site-footer.html
@@ -1,0 +1,19 @@
+<section class="lm-news">
+  <p class="lm-label">Newsletter</p>
+  <p>Occasional writing on the American West, agricultural history, and political culture.</p>
+  <form class="lm-form" action="https://buttondown.com/api/emails/embed-subscribe/plainsink" method="post" target="_blank">
+    <input type="email" name="email" placeholder="you@example.com" required aria-label="Email address">
+    <button type="submit">Subscribe</button>
+  </form>
+</section>
+
+<footer class="lm-footer">
+  <div>
+    © 2017&ndash;{{ now.Format "2006" }} Jason A. Heppler. Last updated {{ now.Format "Jan 2, 2006" }}.
+    <a href="/colophon/">Colophon</a>. This site is <a href="/low-impact/">climate&#8209;friendly</a>.
+  </div>
+  <div class="lm-foot-rss">
+    <a href="/feed.xml">RSS</a>
+    <a href="/feed.json">JSON</a>
+  </div>
+</footer>

--- a/themes/sagebrush/layouts/partials/lab/topbar.html
+++ b/themes/sagebrush/layouts/partials/lab/topbar.html
@@ -1,0 +1,30 @@
+<header class="lm-topbar">
+  <a href="/" class="lm-mark" aria-label="Home">
+    <svg viewBox="0 0 32 32" fill="none" stroke="currentColor" stroke-linecap="round" aria-hidden="true">
+      <circle cx="16" cy="16" r="14.6" stroke-width="1.5"/>
+      <path d="M16 25 C 15 20 12.5 17 10 14" stroke-width="2"/>
+      <path d="M16 25 C 16 19 16 15 16 10.5" stroke-width="2"/>
+      <path d="M16 25 C 17 20 19.5 17 22 14" stroke-width="2"/>
+    </svg>
+  </a>
+  <nav class="lm-nav">
+    <a href="/archive/">Writing</a>
+    <a href="/publications/">Publications</a>
+    <a href="/research/">Digital History</a>
+    <a href="/books/">Bookshelf</a>
+    <a href="/about/">About</a>
+    <button class="lm-theme" type="button" aria-label="Switch color theme (auto, light, dark)" title="Theme">
+      <svg class="lm-ic-auto" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true">
+        <circle cx="12" cy="12" r="9"/>
+        <path d="M12 3 A9 9 0 0 0 12 21 Z" fill="currentColor" stroke="none"/>
+      </svg>
+      <svg class="lm-ic-light" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" aria-hidden="true">
+        <circle cx="12" cy="12" r="4"/>
+        <path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"/>
+      </svg>
+      <svg class="lm-ic-dark" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+        <path d="M20 14.5A8 8 0 1 1 9.5 4 6.3 6.3 0 0 0 20 14.5Z"/>
+      </svg>
+    </button>
+  </nav>
+</header>

--- a/themes/sagebrush/layouts/partials/min/author-card.html
+++ b/themes/sagebrush/layouts/partials/min/author-card.html
@@ -1,0 +1,12 @@
+<aside class="lm-author p-author h-card">
+  <img src="/assets/images/portrait.webp" alt="Jason A. Heppler" class="u-photo" width="56" height="56">
+  <div class="lm-author-text">
+    <span class="lm-author-name p-name">Jason A. Heppler</span>
+    <span class="lm-author-role">Environmental &amp; digital historian</span>
+  </div>
+  <div class="lm-author-links">
+    {{ with site.Params.social.bluesky }}<a href="{{ . }}">Bluesky</a>{{ end }}
+    {{ with site.Params.social.mastodon }}<a href="{{ . }}" rel="me">Mastodon</a>{{ end }}
+    <a href="https://github.com/hepplerj">GitHub</a>
+  </div>
+</aside>

--- a/themes/sagebrush/layouts/partials/min/carbon-badge.html
+++ b/themes/sagebrush/layouts/partials/min/carbon-badge.html
@@ -1,0 +1,5 @@
+{{/* CO2 estimate (Sustainable Web Design model): ~0.5g per MB transferred.
+     Page weight ≈ WordCount × 7 bytes (text) + 30KB base. Result in grams. */}}
+{{ $grams := div (add (mul .WordCount 7.0) 30000.0) 2000000.0 }}
+<a href="/low-impact/" class="lm-carbon" title="Estimated carbon per visit">
+  <svg class="lm-carbon-leaf" viewBox="0 0 24 24" width="13" height="13" fill="currentColor" aria-hidden="true"><path d="M17 8C8 10 5.9 16.17 3.82 21.34l1.89.66.95-2.3c.48.17.98.3 1.34.3C19 20 22 3 22 3c-1 2-8 2.25-13 3.25S2 11.5 2 13.5s1.75 3.75 1.75 3.75C7 8 17 8 17 8z"/></svg>~{{ printf "%.3f" $grams }}g CO<sub>2</sub></a>

--- a/themes/sagebrush/layouts/partials/min/footer.html
+++ b/themes/sagebrush/layouts/partials/min/footer.html
@@ -1,0 +1,18 @@
+<section class="lm-news">
+  <p class="lm-label">Newsletter</p>
+  <p>Occasional writing on the American West, agricultural history, and political culture.</p>
+  <form class="lm-form" action="https://buttondown.com/api/emails/embed-subscribe/plainsink" method="post" target="_blank">
+    <input type="email" name="email" placeholder="you@example.com" required aria-label="Email address">
+    <button type="submit">Subscribe</button>
+  </form>
+</section>
+
+<footer class="lm-footer">
+  <div>
+    © 2008&ndash;{{ now.Format "2006" }} Jason A. Heppler. Last updated {{ now.Format "Jan 2, 2006" }}. My writing, photography, and the design of this website are <a href="https://www.copyright.gov/help/faq/faq-general.html#mywork">copyrighted</a>. Feel free to ask if you want to reuse any content beyond the bounds of fair use. Powered by <a href="https://gohugo.io/">Hugo</a> and <a href="https://www.ahillofbeans.com/">coffee</a>. Made in Nebraska. <a href="/colophon/">Colophon</a>. This site is <a href="/low-impact/">climate&#8209;friendly</a>.
+  </div>
+  <div class="lm-foot-rss">
+    <a href="/feed.xml">RSS</a>
+    <a href="/feed.json">JSON</a>
+  </div>
+</footer>

--- a/themes/sagebrush/layouts/partials/min/head.html
+++ b/themes/sagebrush/layouts/partials/min/head.html
@@ -1,0 +1,102 @@
+<link href="http://gmpg.org/xfn/11" rel="profile" />
+<meta http-equiv="content-type" content="text/html; charset=utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+
+{{ if eq hugo.Environment "development" }}
+<meta name="robots" content="noindex, nofollow" />
+{{ else }}
+<meta name="robots" content="index,follow" />
+{{ end }}
+
+{{ if .IsPage }}
+<title>{{ .Title }} · {{ .Site.Title }}</title>
+{{ else }}
+<title>{{ .Site.Title }} · Environmental and Digital Historian</title>
+{{ end }}
+
+{{ if .Description }}
+<meta name="description" content="{{ .Description }}" />
+{{ else if .IsPage }}
+<meta name="description" content="{{ .Summary | plainify }}" />
+{{ end }}
+
+<!-- DNS Prefetch -->
+<link rel="dns-prefetch" href="https://jasonheppler.org" />
+
+<!-- Me -->
+<meta name="author" content="Jason A. Heppler" />
+<meta name="copyright" content="&copy; Copyright 2008 to Present" />
+<meta name="HandheldFriendly" content="True" />
+<meta name="MobileOptimized" content="320" />
+<meta name="apple-mobile-web-app-capable" content="yes" />
+<link href="https://micro.blog/jaheppler" rel="me" />
+<link href="https://hcommons.social/@jaheppler" rel="me" />
+<link href="https://historians.social/@jaheppler" rel="me" />
+<link href="https://hcommons.org/members/hepplerj/" rel="me" />
+<link href="https://orcid.org/0000-0003-4158-6186" rel="me" />
+<link href="https://github.com/hepplerj" rel="me" />
+<link href="https://scholar.google.com/citations?user=X2hGnS4AAAAJ" rel="me" />
+<link href="https://www.zotero.org/hepplerj/" rel="me" />
+<link href="https://www.linkedin.com/in/jasonheppler/" rel="me" />
+<link href="https://indieweb.org/User:Jasonheppler.org" rel="me" />
+
+<!-- RDFa Metadata (in DublinCore) -->
+<meta property="dc:title" content="{{ .Title }}" />
+<meta property="dc:creator" content="Jason A. Heppler" />
+<meta property="dc:date" content="{{ .Site.Lastmod }}" />
+<meta property="dc:format" content="text/html" />
+<meta property="dc:language" content="en" />
+<meta property="dc:identifier" content="{{ .Permalink }}" />
+<meta property="dc:rights" content="CC BY-NC-SA 3.0" />
+<meta property="dc:source" content="Jason Heppler weblog" />
+<meta property="dc:subject" content="History" />
+<meta property="dc:type" content="website" />
+
+<!-- Google Scholar Metadata -->
+<meta name="citation_author" content="Jason A. Heppler" />
+<meta name="citation_date" content="{{ .Site.Lastmod }}" />
+<meta name="citation_title" content="{{ .Title }}" />
+<meta name="citation_journal_title" content="Jason Heppler weblog" />
+
+<!-- Open Graph Metadata -->
+<meta property="og:title" content="{{ .Title }} | {{ .Site.Title }}" />
+<meta property="og:author" content="Jason A. Heppler" />
+<meta property="og:site_name" content="Jason Heppler - Historian" />
+<meta property="og:url" content="{{ .Permalink }}" />
+<meta property="og:type" content="website" />
+<meta property="og:description" content="{{ with .Description }}{{ . }}{{ else }}{{ .Summary | plainify }}{{ end }}" />
+
+<!-- Twitter Metadata -->
+<meta property="twitter:account_id" content="16240799" />
+<meta name="twitter:card" content="summary" />
+<meta name="twitter:site" content="@jaheppler" />
+<meta name="twitter:creator" content="@jaheppler" />
+<meta name="twitter:url" content="{{ .Permalink }}" />
+<meta name="twitter:title" content="{{ .Title }} | {{ .Site.Title }}" />
+<meta name="twitter:description" content="{{ with .Description }}{{ . }}{{ else }}{{ .Summary | plainify }}{{ end }}" />
+
+<!-- Webmentions (receiving endpoint; display intentionally omitted) -->
+<link rel="webmention" href="https://webmention.io/jasonheppler.org/webmention" />
+<link rel="pingback" href="https://webmention.io/jasonheppler.org/xmlrpc" />
+
+<!-- Stylesheet: the single merged sagebrush.css is loaded by baseof.html -->
+
+<link rel="shortcut icon" href="/assets/favicon.png" />
+
+<!-- Plausible -->
+<script defer data-domain="jasonheppler.org" src="https://plausible.io/js/plausible.js"></script>
+
+<link rel="canonical" href="{{ .Permalink }}" />
+<link rel="home" href="https://jasonheppler.org" />
+<link rel="alternate" type="application/rss+xml" href="/feed.xml" title="Jason Heppler's blog." />
+<link rel="alternate" type="application/feed+json" href="/feed.json" title="Jason Heppler's blog (JSON Feed)." />
+
+<!-- Flash-free theme (light / dark / auto) -->
+<script>
+  (function () {
+    var mode = localStorage.getItem('lm-theme-mode') || 'auto';
+    var root = document.documentElement;
+    root.setAttribute('data-mode', mode);
+    if (mode === 'light' || mode === 'dark') root.setAttribute('data-theme', mode);
+  })();
+</script>

--- a/themes/sagebrush/layouts/partials/min/scripts.html
+++ b/themes/sagebrush/layouts/partials/min/scripts.html
@@ -1,0 +1,16 @@
+<!-- Theme UI: email, mobile nav, theme switcher -->
+{{ $ui := resources.Get "javascripts/min-ui.js" | js.Build | resources.Minify | resources.Fingerprint "sha512" }}
+<script src="{{ $ui.RelPermalink }}" integrity="{{ $ui.Data.Integrity }}" defer></script>
+
+<!-- Keyboard shortcuts, footnotes, lightbox (hepp.js) -->
+{{ $js := resources.Get "javascripts/hepp.js" | js.Build | resources.Minify | resources.Fingerprint "sha512" }}
+<script type="module" src="{{ $js.RelPermalink }}" integrity="{{ $js.Data.Integrity }}" async></script>
+
+<!-- ⌘K fast search -->
+<div id="fastSearch" role="dialog" aria-modal="true" aria-label="Site search" style="display:none">
+  <div class="fast-search-box">
+    <input id="searchInput" tabindex="0" placeholder="Search…" aria-label="Search" autocomplete="off" spellcheck="false">
+    <ul id="searchResults" role="listbox"></ul>
+  </div>
+</div>
+<script src="/js/fastsearch.js"></script>

--- a/themes/sagebrush/layouts/partials/min/topbar.html
+++ b/themes/sagebrush/layouts/partials/min/topbar.html
@@ -1,0 +1,30 @@
+<header class="lm-topbar">
+  <a href="/" class="lm-mark">Jason Heppler</a>
+  <button class="lm-nav-toggle" type="button" aria-label="Menu" aria-expanded="false" aria-controls="lmNav">
+    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true">
+      <line x1="3" y1="6" x2="21" y2="6"/>
+      <line x1="3" y1="12" x2="21" y2="12"/>
+      <line x1="3" y1="18" x2="21" y2="18"/>
+    </svg>
+  </button>
+  <nav class="lm-nav" id="lmNav">
+    <a href="/archive/"{{ if or (in (slice "blog" "microblog") .Section) (eq .RelPermalink "/archive/") }} class="lm-nav-active"{{ end }}>Writing</a>
+    <a href="/publications/"{{ if eq .Section "publications" }} class="lm-nav-active"{{ end }}>Publications</a>
+    <a href="/research/"{{ if or (eq .Section "projects") (eq .RelPermalink "/research/") }} class="lm-nav-active"{{ end }}>Digital History</a>
+    <a href="/books/"{{ if eq .Section "books" }} class="lm-nav-active"{{ end }}>Bookshelf</a>
+    <a href="/about/"{{ if eq .RelPermalink "/about/" }} class="lm-nav-active"{{ end }}>About</a>
+    <button class="lm-theme" type="button" aria-label="Switch color theme (auto, light, dark)" title="Theme">
+      <svg class="lm-ic-auto" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true">
+        <circle cx="12" cy="12" r="9"/>
+        <path d="M12 3 A9 9 0 0 0 12 21 Z" fill="currentColor" stroke="none"/>
+      </svg>
+      <svg class="lm-ic-light" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" aria-hidden="true">
+        <circle cx="12" cy="12" r="4"/>
+        <path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"/>
+      </svg>
+      <svg class="lm-ic-dark" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+        <path d="M20 14.5A8 8 0 1 1 9.5 4 6.3 6.3 0 0 0 20 14.5Z"/>
+      </svg>
+    </button>
+  </nav>
+</header>

--- a/themes/sagebrush/layouts/projects/single.html
+++ b/themes/sagebrush/layouts/projects/single.html
@@ -1,0 +1,4 @@
+{{/* Standalone /projects/ apps ship their own <html>, styles, and scripts.
+     No define "main" block, so this bypasses the theme baseof/chrome and
+     renders the project's own document bare. */}}
+{{ .Content }}

--- a/themes/sagebrush/layouts/publications/list.html
+++ b/themes/sagebrush/layouts/publications/list.html
@@ -1,0 +1,54 @@
+{{ define "main" }}
+<header class="lm-archive-head">
+  <p class="lm-label">Publications</p>
+  <h1 class="lm-archive-title">Books, articles &amp; essays</h1>
+  <nav class="lm-pub-tabs">
+    <a href="#books">Books</a>
+    <a href="#articles">Articles &amp; Chapters</a>
+    <a href="#essays">Essays</a>
+    <span class="lm-dot-sep">·</span>
+    <a href="/files/jah-cv.pdf" class="lm-pub-tab-cv">Full CV &nearr;</a>
+  </nav>
+</header>
+
+<!-- Books -->
+<h2 class="lm-pub-h2" id="books">Books</h2>
+{{ $pubs := .Pages.ByDate.Reverse }}
+{{ range where $pubs ".Params.image" "ne" nil }}
+<div class="lm-pub-card">
+  <a href="{{ .RelPermalink }}" class="lm-pub-card-cover">
+    <img src="/assets/images/{{ .Params.image }}" alt="{{ .Title }}" loading="lazy" decoding="async">
+  </a>
+  <div class="lm-pub-card-info">
+    <h3 class="lm-pub-card-title">{{ .Title }}</h3>
+    <p class="lm-pub-card-meta">{{ with .Params.publisher }}{{ . }}{{ end }}{{ with .Params.year }}, {{ . }}{{ end }}</p>
+    <div class="lm-pub-card-desc">{{ .Summary }}</div>
+    <a href="{{ .RelPermalink }}" class="lm-more">More about this book &rarr;</a>
+  </div>
+</div>
+{{ end }}
+
+<!-- Articles & Essays from data file -->
+{{ with hugo.Data.essays_criticism }}
+{{ $all := where . "published" "ne" false }}
+{{ $articles := where $all "type" "in" (slice "Article" "Chapter") }}
+{{ if $articles }}
+<h2 class="lm-pub-h2" id="articles">Articles &amp; Book Chapters</h2>
+<ol class="lm-pub-list">
+  {{ range sort $articles "year" "desc" }}
+  <li>{{ with .coauthor }}{{ . }} and Jason A. Heppler, {{ end }}{{ if .url }}<a href="{{ .url }}">{{ .title }}</a>{{ else }}&ldquo;{{ .title }}&rdquo;{{ end }}{{ with .publication }}, <em>{{ . }}</em>{{ end }} ({{ .year }}).{{ with .note }} {{ . }}{{ end }}</li>
+  {{ end }}
+</ol>
+{{ end }}
+
+{{ $essays := where $all "type" "in" (slice "Essay" "Review") }}
+{{ if $essays }}
+<h2 class="lm-pub-h2" id="essays">Essays &amp; Criticism</h2>
+<ol class="lm-pub-list">
+  {{ range sort $essays "year" "desc" }}
+  <li>{{ with .coauthor }}{{ . }} and {{ end }}{{ if .url }}<a href="{{ .url }}">{{ .title }}</a>{{ else }}&ldquo;{{ .title }}&rdquo;{{ end }}{{ with .publication }}, <em>{{ . }}</em>{{ end }} ({{ .year }}).</li>
+  {{ end }}
+</ol>
+{{ end }}
+{{ end }}
+{{ end }}

--- a/themes/sagebrush/layouts/publications/single.html
+++ b/themes/sagebrush/layouts/publications/single.html
@@ -1,0 +1,82 @@
+{{ define "main" }}
+{{ if .Params.image }}
+<a href="/publications/" class="lm-breadcrumb">&larr; Publications</a>
+
+<section class="lm-bookhead">
+  <div class="lm-bookhead-cover">
+    <img src="/assets/images/{{ .Params.image }}" alt="{{ .Title }}" loading="lazy" decoding="async">
+  </div>
+  <div class="lm-bookhead-info">
+    <p class="lm-label">Book{{ with .Params.year }} · {{ . }}{{ end }}</p>
+    <h1 class="lm-bookhead-title">{{ .Title }}</h1>
+    {{ with .Params.author }}<p class="lm-bookhead-author">by {{ . }}</p>{{ end }}
+    {{ with .Params.publisher }}<p class="lm-bookhead-publisher">{{ . }}</p>{{ end }}
+
+    {{ if .Params.purchase_links }}
+    <div class="lm-bookhead-buy">
+      {{ range .Params.purchase_links }}
+      <a href="{{ .url }}" class="lm-btn">{{ .name }}</a>
+      {{ end }}
+      {{ with .Params.library_link }}{{ if .url }}<a href="{{ .url }}" class="lm-btn lm-btn-outline">Find in a library</a>{{ end }}{{ end }}
+    </div>
+    {{ end }}
+
+    <div class="lm-prose lm-bookhead-prose">{{ .Content }}</div>
+  </div>
+</section>
+
+{{ with .Params.endorsements }}
+<section class="lm-praise">
+  <p class="lm-label">Praise</p>
+  <div class="lm-praise-grid">
+    {{ range . }}
+    <blockquote class="lm-praise-quote">
+      <p>&ldquo;{{ .quote }}&rdquo;</p>
+      <cite>{{ .author }}</cite>
+    </blockquote>
+    {{ end }}
+  </div>
+</section>
+{{ end }}
+
+{{ with .Params.reviews }}
+<section class="lm-reviews">
+  <p class="lm-label">Reviews</p>
+  {{ range . }}
+  {{ $pub := .publication }}{{ $url := .url }}
+  <blockquote class="lm-review-quote">
+    {{ with .quote }}<p>&ldquo;{{ . }}&rdquo;</p>{{ end }}
+    <cite>{{ .author }}{{ with $pub }}, {{ if $url }}<a href="{{ $url }}">{{ . }}</a>{{ else }}{{ . }}{{ end }}{{ end }}</cite>
+  </blockquote>
+  {{ end }}
+</section>
+{{ end }}
+
+{{ if or .Params.purchase_links .Params.library_link }}
+<section class="lm-buy-footer">
+  <p class="lm-label">Get the book</p>
+  <p class="lm-buy-links">
+    {{ range $i, $l := .Params.purchase_links }}{{ if $i }} · {{ end }}<a href="{{ $l.url }}">{{ $l.name }}</a>{{ end }}
+    {{ with .Params.library_link }}{{ if .url }} · <a href="{{ .url }}">Find in a library</a>{{ end }}{{ end }}
+  </p>
+</section>
+{{ end }}
+
+{{ if or .Params.isbn_paperback .Params.isbn_hardcover .Params.isbn_ebook }}
+<section class="lm-isbn">
+  <div class="lm-isbn-grid">
+    {{ with .Params.isbn_paperback }}<div class="lm-isbn-item"><span class="lm-isbn-label">Paperback ISBN</span><span class="lm-isbn-number">{{ . }}</span></div>{{ end }}
+    {{ with .Params.isbn_hardcover }}<div class="lm-isbn-item"><span class="lm-isbn-label">Hardcover ISBN</span><span class="lm-isbn-number">{{ . }}</span></div>{{ end }}
+    {{ with .Params.isbn_ebook }}<div class="lm-isbn-item"><span class="lm-isbn-label">Ebook ISBN</span><span class="lm-isbn-number">{{ . }}</span></div>{{ end }}
+  </div>
+</section>
+{{ end }}
+
+{{ else }}
+<header class="lm-archive-head">
+  <p class="lm-label">Research</p>
+  <h1 class="lm-archive-title">{{ .Title }}</h1>
+</header>
+<div class="lm-prose lm-about-body">{{ .Content }}</div>
+{{ end }}
+{{ end }}

--- a/themes/sagebrush/layouts/tags/list.html
+++ b/themes/sagebrush/layouts/tags/list.html
@@ -1,0 +1,13 @@
+{{ define "main" }}
+<header class="lm-archive-head">
+  <p class="lm-label">Topics</p>
+  <h1 class="lm-archive-title">{{ .Title | default "Tags" }}</h1>
+  <p class="lm-archive-lead">Every topic written about here, by frequency.</p>
+</header>
+
+<div class="lm-tag-cloud">
+  {{ range site.Taxonomies.tags.ByCount }}
+  <a href="{{ .Page.RelPermalink }}" class="lm-tag-chip">{{ .Page.Title | humanize }} <span class="lm-chip-n">{{ .Count }}</span></a>
+  {{ end }}
+</div>
+{{ end }}

--- a/themes/sagebrush/layouts/tags/term.html
+++ b/themes/sagebrush/layouts/tags/term.html
@@ -1,0 +1,16 @@
+{{ define "main" }}
+<header class="lm-archive-head">
+  <p class="lm-label">Tag</p>
+  <h1 class="lm-archive-title">{{ .Title | humanize }}</h1>
+  <p class="lm-archive-lead">{{ len .Pages }} post{{ if ne (len .Pages) 1 }}s{{ end }} tagged &ldquo;{{ .Title | humanize }}&rdquo;.</p>
+</header>
+
+<div class="lm-stream">
+  {{ range .Pages.ByDate.Reverse }}
+  <a href="{{ .RelPermalink }}" class="lm-row">
+    <span class="lm-row-title">{{ .Title }}</span>
+    <time class="lm-row-date" datetime="{{ .Date.Format "2006-01-02" }}">{{ .Date.Format "Jan 2, 2006" }}</time>
+  </a>
+  {{ end }}
+</div>
+{{ end }}


### PR DESCRIPTION
Isolates the site design into a single self-contained theme, so edits target one theme instead of leaking into the parked Fog & Pine base.

## What changed
**Theme structure — Sagebrush is now standalone.** It was a skin layered on Pine via an ordered fallback (`theme: [sagebrush, pine]`): every inner-page template still lived in `themes/pine/`, so editing them meant editing the "other" theme, and the warm reskin depended on two CSS files loading in the right order.

- `config.yaml` → **`theme: sagebrush`** (single theme). The ~33 templates + `min-ui.js` Sagebrush borrowed are absorbed into `themes/sagebrush/` via a no-clobber copy that preserves Sagebrush's own `baseof.html`/`index.html` (hash-verified).
- `themes/pine` (Fog & Pine) and `themes/big-sky` stay **parked in the tree as inactive references**, untouched.

**One stylesheet.** `minimal.css` is folded into a single `sagebrush.css` — Pine's reset + `lm-` component library first, then Sagebrush's fonts, tokens, and `bf-`/`tw-` components. Pine's token blocks and its unused JetBrains Mono `@font-face` are dropped; Sagebrush's `:root` is the **sole** token definition (light + dark map to the same warm values). Loaded once by `baseof`; `min/head.html` and the `/lab/` prototype head repointed. No more two-file token-override dance.

**Colophon accuracy.** Corrected the typography section to **Spectral + IBM Plex Mono** (self-hosted, subset), and dropped the stale "native system font stack," "avoids web-font downloads," and "auto/light/dark toggle" claims — none of which are true under Sagebrush (there's no theme toggle and the palette is a single warm light theme).

## Verification
- `hugo` build clean.
- Every route 200 (`/`, blog single, `/publications/`, `/books/`, `/archive/`, `/microblog/`, `/about/`, `/research/`, `/tweets/`, `/lab/minimal/`); intentional 404s only.
- Inner pages load **exactly one** stylesheet; computed tokens **identical** before/after the fold (`--paper #efe8da`, `--muted #574f40`, Spectral/IBM Plex, `--col 720px`). No console errors; blog single pixel-identical.

## Note
Includes the small prose tweaks discussed alongside this work (footnotes heading → screen-reader-only, darker WCAG-AA `--muted`, warm highlighter `<mark>`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)